### PR TITLE
Support tagging for workflow resource

### DIFF
--- a/aws-transfer-workflow/aws-transfer-workflow.json
+++ b/aws-transfer-workflow/aws-transfer-workflow.json
@@ -258,7 +258,8 @@
   "handlers": {
     "create": {
       "permissions": [
-        "transfer:CreateWorkflow"
+        "transfer:CreateWorkflow",
+        "transfer:TagResource"
       ]
     },
     "read": {

--- a/aws-transfer-workflow/resource-role.yaml
+++ b/aws-transfer-workflow/resource-role.yaml
@@ -27,6 +27,7 @@ Resources:
                 - "transfer:DeleteWorkflow"
                 - "transfer:DescribeWorkflow"
                 - "transfer:ListWorkflows"
+                - "transfer:TagResource"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/Converter.java
+++ b/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/Converter.java
@@ -26,7 +26,7 @@ public class Converter {
                     .build();
         }
 
-        static software.amazon.transfer.workflow.Tag toModel(Tag tag) {
+        static software.amazon.transfer.workflow.Tag fromSdk(Tag tag) {
             if (tag == null) {
                 return null;
             }
@@ -91,7 +91,7 @@ public class Converter {
             return sdkWorkflowStep.build();
         }
 
-        static software.amazon.transfer.workflow.WorkflowStep toModel(WorkflowStep workflowStep) {
+        static software.amazon.transfer.workflow.WorkflowStep fromSdk(WorkflowStep workflowStep) {
             if (workflowStep == null) {
                 return null;
             }
@@ -142,7 +142,7 @@ public class Converter {
                         .name(workflowStep.tagStepDetails().name())
                         .tags(workflowStep.tagStepDetails().tags()
                                 .stream()
-                                .map(S3TagConverter::toModel)
+                                .map(S3TagConverter::fromSdk)
                                 .collect(Collectors.toSet()))
                         .build());
             }
@@ -162,7 +162,7 @@ public class Converter {
                     .build();
         }
 
-        static software.amazon.transfer.workflow.S3Tag toModel(S3Tag s3tag) {
+        static software.amazon.transfer.workflow.S3Tag fromSdk(S3Tag s3tag) {
             if (s3tag == null) {
                 return null;
             }

--- a/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/ReadHandler.java
+++ b/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/ReadHandler.java
@@ -59,17 +59,17 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
                     .onExceptionSteps((CollectionUtils.isNullOrEmpty(describedWorkflow.onExceptionSteps())) ?
                             null : describedWorkflow.onExceptionSteps()
                             .stream()
-                            .map(Converter.WorkflowStepConverter::toModel)
+                            .map(Converter.WorkflowStepConverter::fromSdk)
                             .collect(Collectors.toList()))
                     .steps((CollectionUtils.isNullOrEmpty(describedWorkflow.steps())) ?
                             null : describedWorkflow.steps()
                             .stream()
-                            .map(Converter.WorkflowStepConverter::toModel)
+                            .map(Converter.WorkflowStepConverter::fromSdk)
                             .collect(Collectors.toList()))
                     .tags((CollectionUtils.isNullOrEmpty(describedWorkflow.tags())) ?
                             null : describedWorkflow.tags()
                             .stream()
-                            .map(Converter.TagConverter::toModel)
+                            .map(Converter.TagConverter::fromSdk)
                             .collect(Collectors.toSet()))
                     .workflowId(model.getWorkflowId())
                     .build();

--- a/aws-transfer-workflow/src/test/java/software/amazon/transfer/workflow/AbstractTestBase.java
+++ b/aws-transfer-workflow/src/test/java/software/amazon/transfer/workflow/AbstractTestBase.java
@@ -7,7 +7,7 @@ import software.amazon.awssdk.services.transfer.model.OverwriteExisting;
 import software.amazon.awssdk.services.transfer.model.WorkflowStepType;
 
 public class AbstractTestBase {
-  static String TEST_DESCRIPTION = "uluru unit test";
+  static String TEST_DESCRIPTION = "unit test";
 
   public List<WorkflowStep> getModelCopyWorkflowSteps() {
     WorkflowStep step = WorkflowStep.builder()


### PR DESCRIPTION
Tags are not passing to workflow while local test. This fix added the necessary `tagResource` permission to fix that.

Also modified method name for easier understanding.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
