### PR TITLE
Add length constraint for S3InputFileLocation Key

### DIFF
--- a/aws-transfer-workflow/aws-transfer-workflow.json
+++ b/aws-transfer-workflow/aws-transfer-workflow.json
@@ -41,7 +41,9 @@
         "Key": {
           "description": "The name assigned to the file when it was created in S3. You use the object key to retrieve the object.",
           "type": "string",
-          "pattern": "[\\P{M}\\p{M}]*"
+          "pattern": "[\\P{M}\\p{M}]*",
+          "minLength": 0,
+          "maxLength": 1024
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Add missing length constraint according to https://docs.aws.amazon.com/transfer/latest/userguide/API_S3InputFileLocation.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
