### PR TITLE
Fix cfn validate warning for insertionOrder

### DIFF
--- a/aws-transfer-workflow/aws-transfer-workflow.json
+++ b/aws-transfer-workflow/aws-transfer-workflow.json
@@ -194,6 +194,7 @@
       "type": "array",
       "maxItems": 8,
       "uniqueItems": true,
+      "insertionOrder": true,
       "items": {
         "$ref": "#/definitions/WorkflowStep"
       }
@@ -203,6 +204,7 @@
       "type": "array",
       "maxItems": 8,
       "uniqueItems": true,
+      "insertionOrder": true,
       "items": {
         "$ref": "#/definitions/WorkflowStep"
       }


### PR DESCRIPTION
before:
```
Explicitly specify value for insertionOrder for array: OnExceptionSteps
Explicitly specify value for insertionOrder for array: Steps
Could not validate regular expression: ^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$
Could not validate regular expression: ^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$
Could not validate regular expression: [\P{M}\p{M}]*
Could not validate regular expression: ^[\w- ]*$
Resource schema is valid.
```
after: 
```
cfn validate
Could not validate regular expression: ^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$
Could not validate regular expression: ^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$
Could not validate regular expression: [\P{M}\p{M}]*
Could not validate regular expression: ^[\w- ]*$
Resource schema is valid.
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
