### PR TITLE
Fix cfn validate warning for regex

### DIFF
--- a/aws-transfer-workflow/aws-transfer-workflow.json
+++ b/aws-transfer-workflow/aws-transfer-workflow.json
@@ -9,14 +9,12 @@
         "Key": {
           "description": "The name assigned to the tag that you create.",
           "type": "string",
-          "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$",
           "minLength": 1,
           "maxLength": 128
         },
         "Value": {
           "description": "The value that corresponds to the key.",
           "type": "string",
-          "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$",
           "minLength": 0,
           "maxLength": 256
         }
@@ -41,7 +39,7 @@
         "Key": {
           "description": "The name assigned to the file when it was created in S3. You use the object key to retrieve the object.",
           "type": "string",
-          "pattern": "[\\P{M}\\p{M}]*",
+          "pattern": ".*",
           "minLength": 0,
           "maxLength": 1024
         }
@@ -222,7 +220,7 @@
     "Description": {
       "description": "A textual description for the workflow.",
       "type": "string",
-      "pattern": "^[\\w- ]*$",
+      "pattern": "^[\\w\\- ]*$",
       "minLength": 0,
       "maxLength": 256
     },


### PR DESCRIPTION
### Notes
* Remove pattern checking for tags
* Replace `[\\P{M}\\p{M}]*` with `.*` for matching any characters
* Fix `^[\\w- ]*$` with `"^[\\w\\- ]*$`

checked on https://regex101.com/ 
>\P{M} matches any characters that \p{M} does not
\p{M} matches a character intended to be combined with another character (e.g. accents, umlauts, enclosing boxes, etc.)

cfn is using [java.util.regex.Pattern](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-regexes.html)

### Testing
```plain
cfn validate
Resource schema is valid.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
