### PR TITLE
fix: update handlers to surface error messages

### DIFF
--- a/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/CreateHandler.java
+++ b/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/CreateHandler.java
@@ -77,7 +77,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             model.setAgreementId(response.agreementId());
             logger.log(String.format("%s created successfully", ResourceModel.TYPE_NAME));
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(createAgreementRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("createAgreement", e);
         } catch (ResourceExistsException e) {

--- a/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/DeleteHandler.java
+++ b/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/DeleteHandler.java
@@ -47,7 +47,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
             proxy.injectCredentialsAndInvokeV2(deleteAgreementRequest, client::deleteAgreement);
             logger.log(String.format("%s %s deleted successfully", ResourceModel.TYPE_NAME, model.getPrimaryIdentifier()));
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(deleteAgreementRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("deleteAgreement", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/UpdateHandler.java
+++ b/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/UpdateHandler.java
@@ -109,7 +109,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
                     .status(OperationStatus.SUCCESS)
                     .build();
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(request.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("Updating tags for agreement", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/CreateHandler.java
+++ b/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/CreateHandler.java
@@ -81,7 +81,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             model.setCertificateId(response.certificateId());
             logger.log(String.format("%s created successfully", ResourceModel.TYPE_NAME));
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(importCertificateRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("ImportCertificate", e);
         } catch (ResourceExistsException e) {

--- a/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/DeleteHandler.java
+++ b/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/DeleteHandler.java
@@ -45,7 +45,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
             proxy.injectCredentialsAndInvokeV2(deleteCertificateRequest, client::deleteCertificate);
             logger.log(String.format("%s %s deleted successfully", ResourceModel.TYPE_NAME, model.getPrimaryIdentifier()));
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(deleteCertificateRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("deleteCertificate", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/UpdateHandler.java
+++ b/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/UpdateHandler.java
@@ -111,7 +111,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
                     .status(OperationStatus.SUCCESS)
                     .build();
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(request.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("Updating tags for certificate", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/CreateHandler.java
+++ b/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/CreateHandler.java
@@ -76,7 +76,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             model.setConnectorId(response.connectorId());
             logger.log(String.format("%s created successfully", ResourceModel.TYPE_NAME));
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(createConnectorRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("createConnector", e);
         } catch (ResourceExistsException e) {

--- a/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/DeleteHandler.java
+++ b/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/DeleteHandler.java
@@ -47,7 +47,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
             logger.log(
                     String.format("%s %s deleted successfully", ResourceModel.TYPE_NAME, model.getPrimaryIdentifier()));
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(deleteConnectorRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("deleteConnector", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/UpdateHandler.java
+++ b/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/UpdateHandler.java
@@ -105,7 +105,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
                     .status(OperationStatus.SUCCESS)
                     .build();
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(request.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("Updating tags for connector", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/CreateHandler.java
+++ b/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/CreateHandler.java
@@ -70,7 +70,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             model.setProfileId(response.profileId());
             logger.log(String.format("%s created successfully", ResourceModel.TYPE_NAME));
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(createProfileRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("createProfile", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/DeleteHandler.java
+++ b/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/DeleteHandler.java
@@ -44,7 +44,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
             proxy.injectCredentialsAndInvokeV2(deleteProfileRequest, client::deleteProfile);
             logger.log(String.format("%s %s deleted successfully", ResourceModel.TYPE_NAME, model.getPrimaryIdentifier()));
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(deleteProfileRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("deleteProfile", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/UpdateHandler.java
+++ b/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/UpdateHandler.java
@@ -98,7 +98,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
                     model.getPrimaryIdentifier()));
 
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(request.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("Updating certificates for profile", e);
         } catch (ResourceNotFoundException e) {


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-transfer/issues/37

*Description of changes:*

Surface useful error messages instead of the request body when we receive an `InvalidRequestException` from Transfer Family.

_Disclaimer: I haven't tested the changes. Raising this PR as a possible solution to https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-transfer/issues/37._

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
