### PR TITLE
Display InvalidRequestException message

### DIFF
--- a/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/CreateHandler.java
+++ b/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/CreateHandler.java
@@ -77,7 +77,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             model.setAgreementId(response.agreementId());
             logger.log(String.format("%s created successfully", ResourceModel.TYPE_NAME));
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(createAgreementRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + createAgreementRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("createAgreement", e);
         } catch (ResourceExistsException e) {

--- a/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/DeleteHandler.java
+++ b/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/DeleteHandler.java
@@ -47,7 +47,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
             proxy.injectCredentialsAndInvokeV2(deleteAgreementRequest, client::deleteAgreement);
             logger.log(String.format("%s %s deleted successfully", ResourceModel.TYPE_NAME, model.getPrimaryIdentifier()));
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(deleteAgreementRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + deleteAgreementRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("deleteAgreement", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/ListHandler.java
+++ b/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/ListHandler.java
@@ -71,7 +71,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
                     .status(OperationStatus.SUCCESS)
                     .build();
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(listAgreementsRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + listAgreementsRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("listAgreement", e);
         } catch (TransferException e) {

--- a/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/ReadHandler.java
+++ b/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/ReadHandler.java
@@ -77,7 +77,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
                     .status(OperationStatus.SUCCESS)
                     .build();
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(describeAgreementRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + describeAgreementRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("describeAgreement", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/UpdateHandler.java
+++ b/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/UpdateHandler.java
@@ -109,7 +109,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
                     .status(OperationStatus.SUCCESS)
                     .build();
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(request.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + request.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("Updating tags for agreement", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/CreateHandler.java
+++ b/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/CreateHandler.java
@@ -81,7 +81,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             model.setCertificateId(response.certificateId());
             logger.log(String.format("%s created successfully", ResourceModel.TYPE_NAME));
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(importCertificateRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + importCertificateRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("ImportCertificate", e);
         } catch (ResourceExistsException e) {

--- a/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/DeleteHandler.java
+++ b/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/DeleteHandler.java
@@ -45,7 +45,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
             proxy.injectCredentialsAndInvokeV2(deleteCertificateRequest, client::deleteCertificate);
             logger.log(String.format("%s %s deleted successfully", ResourceModel.TYPE_NAME, model.getPrimaryIdentifier()));
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(deleteCertificateRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + deleteCertificateRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("deleteCertificate", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/ListHandler.java
+++ b/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/ListHandler.java
@@ -74,7 +74,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
                     .status(OperationStatus.SUCCESS)
                     .build();
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(listCertificatesRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + listCertificatesRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("listCertificate", e);
         } catch (TransferException e) {

--- a/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/ReadHandler.java
+++ b/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/ReadHandler.java
@@ -90,7 +90,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
                     .status(OperationStatus.SUCCESS)
                     .build();
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(describeCertificateRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + describeCertificateRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("describeCertificate", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/UpdateHandler.java
+++ b/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/UpdateHandler.java
@@ -111,7 +111,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
                     .status(OperationStatus.SUCCESS)
                     .build();
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(request.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + request.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("Updating tags for certificate", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/CreateHandler.java
+++ b/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/CreateHandler.java
@@ -76,7 +76,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             model.setConnectorId(response.connectorId());
             logger.log(String.format("%s created successfully", ResourceModel.TYPE_NAME));
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(createConnectorRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + createConnectorRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("createConnector", e);
         } catch (ResourceExistsException e) {

--- a/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/DeleteHandler.java
+++ b/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/DeleteHandler.java
@@ -47,7 +47,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
             logger.log(
                     String.format("%s %s deleted successfully", ResourceModel.TYPE_NAME, model.getPrimaryIdentifier()));
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(deleteConnectorRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + deleteConnectorRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("deleteConnector", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/ListHandler.java
+++ b/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/ListHandler.java
@@ -64,7 +64,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
                     .status(OperationStatus.SUCCESS)
                     .build();
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(listConnectorsRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + listConnectorsRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("listConnector", e);
         } catch (TransferException e) {

--- a/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/ReadHandler.java
+++ b/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/ReadHandler.java
@@ -75,7 +75,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
                     .status(OperationStatus.SUCCESS)
                     .build();
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(describeConnectorRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + describeConnectorRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("describeConnector", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/UpdateHandler.java
+++ b/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/UpdateHandler.java
@@ -105,7 +105,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
                     .status(OperationStatus.SUCCESS)
                     .build();
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(request.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + request.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("Updating tags for connector", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/CreateHandler.java
+++ b/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/CreateHandler.java
@@ -70,7 +70,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             model.setProfileId(response.profileId());
             logger.log(String.format("%s created successfully", ResourceModel.TYPE_NAME));
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(createProfileRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + createProfileRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("createProfile", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/DeleteHandler.java
+++ b/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/DeleteHandler.java
@@ -44,7 +44,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
             proxy.injectCredentialsAndInvokeV2(deleteProfileRequest, client::deleteProfile);
             logger.log(String.format("%s %s deleted successfully", ResourceModel.TYPE_NAME, model.getPrimaryIdentifier()));
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(deleteProfileRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + deleteProfileRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("deleteProfile", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/ListHandler.java
+++ b/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/ListHandler.java
@@ -68,7 +68,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
                     .status(OperationStatus.SUCCESS)
                     .build();
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(listProfilesRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + listProfilesRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("listProfiles", e);
         } catch (TransferException e) {

--- a/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/ReadHandler.java
+++ b/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/ReadHandler.java
@@ -71,7 +71,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
                     .status(OperationStatus.SUCCESS)
                     .build();
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(describeProfileRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + describeProfileRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("describeProfile", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/UpdateHandler.java
+++ b/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/UpdateHandler.java
@@ -98,7 +98,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
                     model.getPrimaryIdentifier()));
 
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(request.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + request.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("Updating certificates for profile", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/CreateHandler.java
+++ b/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/CreateHandler.java
@@ -81,7 +81,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             model.setWorkflowId(response.workflowId());
             logger.log(String.format("%s created successfully", ResourceModel.TYPE_NAME));
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(createWorkflowRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + createWorkflowRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("createWorkflow", e);
         } catch (ResourceExistsException e) {

--- a/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/DeleteHandler.java
+++ b/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/DeleteHandler.java
@@ -45,7 +45,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
             proxy.injectCredentialsAndInvokeV2(deleteWorkflowRequest, client::deleteWorkflow);
             logger.log(String.format("%s %s deleted successfully", ResourceModel.TYPE_NAME, model.getPrimaryIdentifier()));
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(deleteWorkflowRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + deleteWorkflowRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("deleteWorkflow", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/ListHandler.java
+++ b/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/ListHandler.java
@@ -64,7 +64,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
                     .status(OperationStatus.SUCCESS)
                     .build();
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(listWorkflowsRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + listWorkflowsRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("listWorkflow", e);
         } catch (TransferException e) {

--- a/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/ReadHandler.java
+++ b/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/ReadHandler.java
@@ -79,7 +79,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
                     .status(OperationStatus.SUCCESS)
                     .build();
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(describeWorkflowRequest.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + describeWorkflowRequest.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("describeWorkflow", e);
         } catch (ResourceNotFoundException e) {

--- a/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/UpdateHandler.java
+++ b/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/UpdateHandler.java
@@ -93,7 +93,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
                     .status(OperationStatus.SUCCESS)
                     .build();
         } catch (InvalidRequestException e) {
-            throw new CfnInvalidRequestException(request.toString(), e);
+            throw new CfnInvalidRequestException(e.getMessage() + " " + request.toString(), e);
         } catch (InternalServiceErrorException e) {
             throw new CfnServiceInternalErrorException("Updating tags for workflow", e);
         } catch (ResourceNotFoundException e) {


### PR DESCRIPTION
*Issue #, if available:* #37

*Description of changes:* CloudFormation's InvalidRequestionException does not surface the exception message passed by Transfer. This change explicitly surfaces the error message.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
