### PR TITLE
XFER-10648: Support SSH User keys managed externally from CFN

### DIFF
--- a/aws-transfer-user/src/main/java/software/amazon/transfer/user/translators/Translator.java
+++ b/aws-transfer-user/src/main/java/software/amazon/transfer/user/translators/Translator.java
@@ -1,15 +1,18 @@
 package software.amazon.transfer.user.translators;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 
+import software.amazon.awssdk.annotations.NotNull;
 import software.amazon.awssdk.services.transfer.model.HomeDirectoryMapEntry;
 import software.amazon.awssdk.services.transfer.model.TagResourceRequest;
 import software.amazon.awssdk.services.transfer.model.UntagResourceRequest;
@@ -163,5 +166,20 @@ public final class Translator {
             model.setServerId(userArn.getServerId());
             model.setUserName(userArn.getUserName());
         }
+    }
+
+    private static final Pattern spaceSqueezer = Pattern.compile("\\s+");
+
+    // Blatantly copied from the API implementation to ensure we compare the
+    // normalized format of the SSH key body in the ReadHandler.
+    private static String canonicalize(String sshPublicKeyBody) {
+        return spaceSqueezer.matcher(sshPublicKeyBody.trim()).replaceAll(" ");
+    }
+
+    public static @NotNull List<String> normalizeSshKeys(List<String> sshPublicKeys) {
+        if (sshPublicKeys == null || sshPublicKeys.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return sshPublicKeys.stream().map(Translator::canonicalize).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
The User Update handler already manages SSH keys such that we only add/remove keys CloudFormation is managing but the Read handler will report back the actual user keys as seen by a DescribeUser request. When keys are added outside CloudFormation this behavior would cause the CFN to report the user has "drifted".

With this change we filter the returned collection of SSH keys to match the expected ones under the assumption that the additional keys are externally managed and CFN should not touch them. If the collection returned is missing expected keys we should observe a "drift" and that should be expected to function.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
