### PR TITLE
Add Cloudformation support for TLS certificates

### DIFF
--- a/aws-transfer-certificate/aws-transfer-certificate.json
+++ b/aws-transfer-certificate/aws-transfer-certificate.json
@@ -32,7 +32,8 @@
       "type": "string",
       "enum": [
         "SIGNING",
-        "ENCRYPTION"
+        "ENCRYPTION",
+        "TLS"
       ]
     },
     "Certificate": {

--- a/aws-transfer-certificate/docs/README.md
+++ b/aws-transfer-certificate/docs/README.md
@@ -50,7 +50,7 @@ _Required_: Yes
 
 _Type_: String
 
-_Allowed Values_: <code>SIGNING</code> | <code>ENCRYPTION</code>
+_Allowed Values_: <code>SIGNING</code> | <code>ENCRYPTION</code> | <code>TLS</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-transfer-certificate/pom.xml
+++ b/aws-transfer-certificate/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>transfer</artifactId>
-            <version>2.21.45</version>
+            <version>2.25.31</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>


### PR DESCRIPTION
*Description of changes:*
Add Cloudformation support for creating a TLS type certificate and also update the sdk to the latest version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
