### PR TITLE
Fix Spotbugs issues with new Uluru checker

### DIFF
--- a/aws-transfer-agreement/spotbugs-exclude.xml
+++ b/aws-transfer-agreement/spotbugs-exclude.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <Match>
+        <Class name="software.amazon.transfer.agreement.HandlerWrapperExecutable"/>
+    </Match>
+    <Match>
+        <Class name="software.amazon.transfer.agreement.HandlerWrapper"/>
+    </Match>
+    <Match>
+        <Class name="software.amazon.transfer.agreement.ResourceModel"/>
+    </Match>
+    <Match>
+        <Bug code="RCN,EI,EI2"/>
+    </Match>
+</FindBugsFilter>

--- a/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/BaseHandlerStd.java
+++ b/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/BaseHandlerStd.java
@@ -1,0 +1,40 @@
+package software.amazon.transfer.agreement;
+
+import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+/**
+ * The purpose of this base class is to allow a simple calling pattern that
+ * makes testing Uluru handlers easier and avoids having to store context
+ * in class fields. The {@link MockableBaseHandler} interface is used to
+ * make isolation of the inner call such that in testing we guarantee that
+ * the caller will not pick the wrong method and avoid human error.
+ */
+public abstract class BaseHandlerStd extends BaseHandler<CallbackContext>
+        implements MockableBaseHandler<CallbackContext> {
+    @Override
+    public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final Logger logger) {
+        return handleRequest(
+                proxy,
+                request,
+                callbackContext != null ? callbackContext : new CallbackContext(),
+                proxy.newProxy(ClientBuilder::getClient),
+                logger);
+    }
+
+    @Override
+    public abstract ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
+            final Logger logger);
+}

--- a/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/CreateHandler.java
+++ b/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/CreateHandler.java
@@ -21,6 +21,7 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.amazonaws.util.CollectionUtils;
@@ -28,23 +29,15 @@ import com.amazonaws.util.CollectionUtils;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class CreateHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public CreateHandler(TransferClient client) {
-        this.client = client;
-    }
+public class CreateHandler extends BaseHandlerStd {
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         final ResourceModel model = request.getDesiredResourceState();
 
@@ -73,7 +66,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                                         .collect(Collectors.toList()))
                 .build();
 
-        try {
+        try (TransferClient client = proxyClient.client()) {
             CreateAgreementResponse response =
                     proxy.injectCredentialsAndInvokeV2(createAgreementRequest, client::createAgreement);
             model.setAgreementId(response.agreementId());

--- a/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/DeleteHandler.java
+++ b/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/DeleteHandler.java
@@ -14,28 +14,20 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class DeleteHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public DeleteHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class DeleteHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         final ResourceModel model = request.getDesiredResourceState();
 
@@ -44,7 +36,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
                 .serverId(model.getServerId())
                 .build();
 
-        try {
+        try (TransferClient client = proxyClient.client()) {
             proxy.injectCredentialsAndInvokeV2(deleteAgreementRequest, client::deleteAgreement);
             logger.log(
                     String.format("%s %s deleted successfully", ResourceModel.TYPE_NAME, model.getPrimaryIdentifier()));

--- a/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/ListHandler.java
+++ b/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/ListHandler.java
@@ -16,28 +16,20 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class ListHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public ListHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class ListHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         final ResourceModel topModel = request.getDesiredResourceState();
         final List<ResourceModel> models = new ArrayList<>();
@@ -48,7 +40,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
                 .nextToken(request.getNextToken())
                 .build();
 
-        try {
+        try (TransferClient client = proxyClient.client()) {
             ListAgreementsResponse response =
                     proxy.injectCredentialsAndInvokeV2(listAgreementsRequest, client::listAgreements);
 

--- a/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/MockableBaseHandler.java
+++ b/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/MockableBaseHandler.java
@@ -1,0 +1,24 @@
+package software.amazon.transfer.agreement;
+
+import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+/**
+ * Interface exposing the only handler method that should be used when
+ * testing Uluru handlers. This provides a mechanism to feed the call chain
+ * a mock client as needed without complex static mocking of the ClientBuilder.
+ *
+ * @param <CallbackT>
+ */
+interface MockableBaseHandler<CallbackT> {
+    ProgressEvent<ResourceModel, CallbackT> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackT callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
+            final Logger logger);
+}

--- a/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/ReadHandler.java
+++ b/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/ReadHandler.java
@@ -18,6 +18,7 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.amazonaws.util.CollectionUtils;
@@ -25,30 +26,21 @@ import com.amazonaws.util.CollectionUtils;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class ReadHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public ReadHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class ReadHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         final ResourceModel model = request.getDesiredResourceState();
         DescribeAgreementRequest describeAgreementRequest = DescribeAgreementRequest.builder()
                 .agreementId(model.getAgreementId())
                 .serverId(model.getServerId())
                 .build();
-        try {
+        try (TransferClient client = proxyClient.client()) {
             DescribeAgreementResponse response =
                     proxy.injectCredentialsAndInvokeV2(describeAgreementRequest, client::describeAgreement);
             logger.log(String.format(

--- a/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/UpdateHandler.java
+++ b/aws-transfer-agreement/src/main/java/software/amazon/transfer/agreement/UpdateHandler.java
@@ -24,28 +24,20 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class UpdateHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public UpdateHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class UpdateHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         final ResourceModel model = request.getDesiredResourceState();
         String arn = String.format(
@@ -82,7 +74,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         Set<Tag> tagsToAdd = Sets.difference(new HashSet<>(desiredTags), new HashSet<>(previousTags));
         Set<Tag> tagsToRemove = Sets.difference(new HashSet<>(previousTags), new HashSet<>(desiredTags));
 
-        try {
+        try (TransferClient client = proxyClient.client()) {
             proxy.injectCredentialsAndInvokeV2(updateAgreementRequest, client::updateAgreement);
             logger.log(String.format("%s updated successfully", ResourceModel.TYPE_NAME));
 

--- a/aws-transfer-agreement/src/test/java/software/amazon/transfer/agreement/AbstractTestBase.java
+++ b/aws-transfer-agreement/src/test/java/software/amazon/transfer/agreement/AbstractTestBase.java
@@ -1,39 +1,135 @@
 package software.amazon.transfer.agreement;
 
+import static org.mockito.Mockito.mock;
+
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-public class AbstractTestBase {
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
 
-    public static String TEST_ARN = "arn:test-arn";
-    public static String TEST_DESCRIPTION = "unit test";
-    public static String TEST_DESCRIPTION_2 = "another unit test";
-    public static String TEST_ACCESS_ROLE = "access-role";
-    public static String TEST_BASE_DIRECTORY = "/";
-    public static String TEST_LOCAL_PROFILE = "local-profile";
-    public static String TEST_PARTNER_PROFILE = "partner-profile";
-    public static String TEST_SERVER_ID = "test-server-id";
-    public static String TEST_STATUS = "ACTIVE";
-    public static String TEST_AGREEMENT_ID = "id";
-    public static Map<String, String> RESOURCE_TAG_MAP = Collections.singletonMap("key", "value");
-    public static Map<String, String> SYSTEM_TAG_MAP =
+import software.amazon.awssdk.awscore.AwsRequest;
+import software.amazon.awssdk.awscore.AwsResponse;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Credentials;
+import software.amazon.cloudformation.proxy.LoggerProxy;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+public abstract class AbstractTestBase {
+
+    public static final String TEST_ARN = "arn:test-arn";
+    public static final String TEST_DESCRIPTION = "unit test";
+    public static final String TEST_DESCRIPTION_2 = "another unit test";
+    public static final String TEST_ACCESS_ROLE = "access-role";
+    public static final String TEST_BASE_DIRECTORY = "/";
+    public static final String TEST_LOCAL_PROFILE = "local-profile";
+    public static final String TEST_PARTNER_PROFILE = "partner-profile";
+    public static final String TEST_SERVER_ID = "test-server-id";
+    public static final String TEST_STATUS = "ACTIVE";
+    public static final String TEST_AGREEMENT_ID = "id";
+    public static final Map<String, String> RESOURCE_TAG_MAP = Collections.singletonMap("key", "value");
+    public static final Map<String, String> SYSTEM_TAG_MAP =
             Collections.singletonMap("aws:cloudformation:stack-name", "StackName");
-    public static Map<String, String> TEST_TAG_MAP =
+    public static final Map<String, String> TEST_TAG_MAP =
             ImmutableMap.of("key", "value", "aws:cloudformation:stack-name", "StackName");
-    public static Set<Tag> MODEL_TAGS =
+    public static final Set<Tag> MODEL_TAGS =
             ImmutableSet.of(Tag.builder().key("key").value("value").build());
-    public static software.amazon.awssdk.services.transfer.model.Tag SDK_MODEL_TAG =
+    public static final software.amazon.awssdk.services.transfer.model.Tag SDK_MODEL_TAG =
             software.amazon.awssdk.services.transfer.model.Tag.builder()
                     .key("key")
                     .value("value")
                     .build();
-    public static software.amazon.awssdk.services.transfer.model.Tag SDK_SYSTEM_TAG =
+    public static final software.amazon.awssdk.services.transfer.model.Tag SDK_SYSTEM_TAG =
             software.amazon.awssdk.services.transfer.model.Tag.builder()
                     .key("aws:cloudformation:stack-name")
                     .value("StackName")
                     .build();
+
+    abstract MockableBaseHandler<CallbackContext> getHandler();
+
+    protected ProgressEvent<ResourceModel, CallbackContext> callHandler(ResourceHandlerRequest<ResourceModel> request) {
+        return getHandler().handleRequest(proxy, request, null, proxyClient, logger);
+    }
+
+    protected static final Credentials MOCK_CREDENTIALS;
+    protected static final LoggerProxy logger;
+
+    static {
+        MOCK_CREDENTIALS = new Credentials("accessKey", "secretKey", "token");
+        logger = new LoggerProxy();
+    }
+
+    protected AmazonWebServicesClientProxy proxy;
+
+    protected ProxyClient<TransferClient> proxyClient;
+
+    @Mock
+    protected TransferClient client;
+
+    @BeforeEach
+    public void setup() {
+        proxy = new AmazonWebServicesClientProxy(
+                logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
+        client = mock(TransferClient.class);
+        proxyClient = MOCK_PROXY(proxy, client);
+    }
+
+    static <T> ProxyClient<T> MOCK_PROXY(final AmazonWebServicesClientProxy proxy, final T sdkClient) {
+        return new ProxyClient<T>() {
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseT injectCredentialsAndInvokeV2(
+                    RequestT request, Function<RequestT, ResponseT> requestFunction) {
+                return proxy.injectCredentialsAndInvokeV2(request, requestFunction);
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+                    CompletableFuture<ResponseT> injectCredentialsAndInvokeV2Async(
+                            RequestT request, Function<RequestT, CompletableFuture<ResponseT>> requestFunction) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <
+                            RequestT extends AwsRequest,
+                            ResponseT extends AwsResponse,
+                            IterableT extends SdkIterable<ResponseT>>
+                    IterableT injectCredentialsAndInvokeIterableV2(
+                            RequestT request, Function<RequestT, IterableT> requestFunction) {
+                return proxy.injectCredentialsAndInvokeIterableV2(request, requestFunction);
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+                    ResponseInputStream<ResponseT> injectCredentialsAndInvokeV2InputStream(
+                            RequestT requestT, Function<RequestT, ResponseInputStream<ResponseT>> function) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+                    ResponseBytes<ResponseT> injectCredentialsAndInvokeV2Bytes(
+                            RequestT requestT, Function<RequestT, ResponseBytes<ResponseT>> function) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public T client() {
+                return sdkClient;
+            }
+        };
+    }
 }

--- a/aws-transfer-agreement/src/test/java/software/amazon/transfer/agreement/BaseHandlerStdTest.java
+++ b/aws-transfer-agreement/src/test/java/software/amazon/transfer/agreement/BaseHandlerStdTest.java
@@ -1,0 +1,56 @@
+package software.amazon.transfer.agreement;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+@ExtendWith(MockitoExtension.class)
+public class BaseHandlerStdTest {
+    @Mock
+    private AmazonWebServicesClientProxy proxy;
+
+    static class MockTestHandler extends BaseHandlerStd {
+        @Override
+        public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+                AmazonWebServicesClientProxy proxy,
+                ResourceHandlerRequest<ResourceModel> request,
+                CallbackContext callbackContext,
+                ProxyClient<TransferClient> proxyClient,
+                Logger logger) {
+            assertNotNull(callbackContext);
+            return null;
+        }
+    }
+
+    @Test
+    void justToCover3LinesOfCode() {
+        var uut = new MockTestHandler();
+
+        // Check with null CallbackContext
+        uut.handleRequest(proxy, null, null, null);
+        verify(proxy, times(1)).newProxy(any());
+        verifyNoMoreInteractions(proxy);
+        reset(proxy);
+
+        // Check with non-null CallbackContext
+        uut.handleRequest(proxy, null, new CallbackContext(), null);
+        verify(proxy, times(1)).newProxy(any());
+        verifyNoMoreInteractions(proxy);
+        reset(proxy);
+    }
+}

--- a/aws-transfer-agreement/src/test/java/software/amazon/transfer/agreement/ReadHandlerTest.java
+++ b/aws-transfer-agreement/src/test/java/software/amazon/transfer/agreement/ReadHandlerTest.java
@@ -7,12 +7,12 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static software.amazon.transfer.agreement.AbstractTestBase.*;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.awssdk.services.transfer.model.DescribeAgreementRequest;
 import software.amazon.awssdk.services.transfer.model.DescribeAgreementResponse;
 import software.amazon.awssdk.services.transfer.model.DescribedAgreement;
 import software.amazon.awssdk.services.transfer.model.InternalServiceErrorException;
@@ -23,28 +23,27 @@ import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 @ExtendWith(MockitoExtension.class)
-public class ReadHandlerTest {
+public class ReadHandlerTest extends AbstractTestBase {
 
-    @Mock
-    private AmazonWebServicesClientProxy proxy;
+    private MockableBaseHandler<CallbackContext> handler;
 
-    @Mock
-    private Logger logger;
+    @Override
+    MockableBaseHandler<CallbackContext> getHandler() {
+        return handler;
+    }
 
-    @Mock
-    private TransferClient client;
+    @BeforeEach
+    public void setupTestData() {
+        handler = new ReadHandler();
+    }
 
     @Test
     public void handleRequest_SimpleSuccess() {
-        final ReadHandler handler = new ReadHandler(client);
-
         ResourceModel model =
                 ResourceModel.builder().agreementId(TEST_AGREEMENT_ID).build();
 
@@ -58,9 +57,9 @@ public class ReadHandlerTest {
                         .status(TEST_STATUS)
                         .build())
                 .build();
-        doReturn(describeAgreementResponse).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doReturn(describeAgreementResponse).when(client).describeAgreement(any(DescribeAgreementRequest.class));
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, null, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = callHandler(request);
         ResourceModel testModel = response.getResourceModel();
 
         assertThat(response).isNotNull();
@@ -75,9 +74,7 @@ public class ReadHandlerTest {
 
     @Test
     public void handleRequest_InvalidRequestExceptionFailed() {
-        ReadHandler handler = new ReadHandler(client);
-
-        doThrow(InvalidRequestException.class).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doThrow(InvalidRequestException.class).when(client).describeAgreement(any(DescribeAgreementRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -85,16 +82,14 @@ public class ReadHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnInvalidRequestException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnInvalidRequestException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_InternalServiceErrorExceptionFailed() {
-        ReadHandler handler = new ReadHandler(client);
-
-        doThrow(InternalServiceErrorException.class).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doThrow(InternalServiceErrorException.class)
+                .when(client)
+                .describeAgreement(any(DescribeAgreementRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -102,16 +97,12 @@ public class ReadHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnServiceInternalErrorException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnServiceInternalErrorException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_ResourceNotFoundExceptionFailed() {
-        ReadHandler handler = new ReadHandler(client);
-
-        doThrow(ResourceNotFoundException.class).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doThrow(ResourceNotFoundException.class).when(client).describeAgreement(any(DescribeAgreementRequest.class));
 
         ResourceModel model = ResourceModel.builder()
                 .agreementId(TEST_AGREEMENT_ID)
@@ -122,16 +113,12 @@ public class ReadHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnNotFoundException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnNotFoundException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_TransferExceptionFailed() {
-        ReadHandler handler = new ReadHandler(client);
-
-        doThrow(TransferException.class).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doThrow(TransferException.class).when(client).describeAgreement(any(DescribeAgreementRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -139,8 +126,6 @@ public class ReadHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnGeneralServiceException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnGeneralServiceException.class, () -> callHandler(request));
     }
 }

--- a/aws-transfer-agreement/src/test/java/software/amazon/transfer/agreement/UpdateHandlerTest.java
+++ b/aws-transfer-agreement/src/test/java/software/amazon/transfer/agreement/UpdateHandlerTest.java
@@ -12,18 +12,16 @@ import static software.amazon.transfer.agreement.AbstractTestBase.*;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import software.amazon.awssdk.services.transfer.TransferClient;
 import software.amazon.awssdk.services.transfer.model.InternalServiceErrorException;
 import software.amazon.awssdk.services.transfer.model.InvalidRequestException;
 import software.amazon.awssdk.services.transfer.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.transfer.model.TagResourceRequest;
 import software.amazon.awssdk.services.transfer.model.TransferException;
-import software.amazon.awssdk.services.transfer.model.TransferRequest;
 import software.amazon.awssdk.services.transfer.model.UntagResourceRequest;
 import software.amazon.awssdk.services.transfer.model.UpdateAgreementRequest;
 import software.amazon.awssdk.services.transfer.model.UpdateAgreementResponse;
@@ -31,28 +29,27 @@ import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 @ExtendWith(MockitoExtension.class)
-public class UpdateHandlerTest {
+public class UpdateHandlerTest extends AbstractTestBase {
 
-    @Mock
-    private AmazonWebServicesClientProxy proxy;
+    private MockableBaseHandler<CallbackContext> handler;
 
-    @Mock
-    private Logger logger;
+    @Override
+    MockableBaseHandler<CallbackContext> getHandler() {
+        return handler;
+    }
 
-    @Mock
-    private TransferClient client;
+    @BeforeEach
+    public void setupTestData() {
+        handler = new UpdateHandler();
+    }
 
     @Test
     public void handleRequest_SimpleSuccess() {
-        final UpdateHandler handler = new UpdateHandler(client);
-
         ResourceModel model = ResourceModel.builder()
                 .agreementId(TEST_AGREEMENT_ID)
                 .description(TEST_DESCRIPTION_2)
@@ -64,9 +61,9 @@ public class UpdateHandlerTest {
 
         UpdateAgreementResponse updateAgreementRequest =
                 UpdateAgreementResponse.builder().agreementId(TEST_AGREEMENT_ID).build();
-        doReturn(updateAgreementRequest).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doReturn(updateAgreementRequest).when(client).updateAgreement(any(UpdateAgreementRequest.class));
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, null, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = callHandler(request);
 
         ResourceModel testModel = response.getResourceModel();
         assertThat(response).isNotNull();
@@ -78,12 +75,11 @@ public class UpdateHandlerTest {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
         assertThat(testModel).hasFieldOrPropertyWithValue("description", TEST_DESCRIPTION_2);
-        verify(proxy, times(1)).injectCredentialsAndInvokeV2(any(UpdateAgreementRequest.class), any());
+        verify(client, times(1)).updateAgreement(any(UpdateAgreementRequest.class));
     }
 
     @Test
     public void handleRequest_AddTagInvoked() {
-        UpdateHandler handler = new UpdateHandler(client);
         Set<Tag> desiredTags = TEST_TAG_MAP.entrySet().stream()
                 .map(tag ->
                         Tag.builder().key(tag.getKey()).value(tag.getValue()).build())
@@ -97,7 +93,7 @@ public class UpdateHandlerTest {
                 .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, null, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = callHandler(request);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -108,13 +104,12 @@ public class UpdateHandlerTest {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
         assertThat(response.getResourceModel().getTags()).isEqualTo(desiredTags);
-        verify(proxy, times(1)).injectCredentialsAndInvokeV2(any(TagResourceRequest.class), any());
-        verify(proxy, times(1)).injectCredentialsAndInvokeV2(any(UpdateAgreementRequest.class), any());
+        verify(client, times(1)).tagResource(any(TagResourceRequest.class));
+        verify(client, times(1)).updateAgreement(any(UpdateAgreementRequest.class));
     }
 
     @Test
     public void handleRequest_RemoveTagInvoked() {
-        UpdateHandler handler = new UpdateHandler(client);
         Set<Tag> systemTags = SYSTEM_TAG_MAP.entrySet().stream()
                 .map(tag ->
                         Tag.builder().key(tag.getKey()).value(tag.getValue()).build())
@@ -128,7 +123,7 @@ public class UpdateHandlerTest {
                 .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, null, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = callHandler(request);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -139,15 +134,13 @@ public class UpdateHandlerTest {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
         assertThat(response.getResourceModel().getTags()).isEqualTo(systemTags);
-        verify(proxy, times(1)).injectCredentialsAndInvokeV2(any(UntagResourceRequest.class), any());
-        verify(proxy, times(1)).injectCredentialsAndInvokeV2(any(UpdateAgreementRequest.class), any());
+        verify(client, times(1)).untagResource(any(UntagResourceRequest.class));
+        verify(client, times(1)).updateAgreement(any(UpdateAgreementRequest.class));
     }
 
     @Test
     public void handleRequest_InvalidRequestExceptionFailed() {
-        UpdateHandler handler = new UpdateHandler(client);
-
-        doThrow(InvalidRequestException.class).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doThrow(InvalidRequestException.class).when(client).updateAgreement(any(UpdateAgreementRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -157,18 +150,12 @@ public class UpdateHandlerTest {
                 .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        assertThrows(CfnInvalidRequestException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnInvalidRequestException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_InternalServiceErrorExceptionFailed() {
-        UpdateHandler handler = new UpdateHandler(client);
-
-        doThrow(InternalServiceErrorException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(TransferRequest.class), any());
+        doThrow(InternalServiceErrorException.class).when(client).updateAgreement(any(UpdateAgreementRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -178,18 +165,12 @@ public class UpdateHandlerTest {
                 .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        assertThrows(CfnServiceInternalErrorException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnServiceInternalErrorException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_ResourceNotFoundExceptionFailed() {
-        UpdateHandler handler = new UpdateHandler(client);
-
-        doThrow(ResourceNotFoundException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(TransferRequest.class), any());
+        doThrow(ResourceNotFoundException.class).when(client).updateAgreement(any(UpdateAgreementRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -199,16 +180,12 @@ public class UpdateHandlerTest {
                 .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        assertThrows(CfnNotFoundException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnNotFoundException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_TransferExceptionFailed() {
-        UpdateHandler handler = new UpdateHandler(client);
-
-        doThrow(TransferException.class).when(proxy).injectCredentialsAndInvokeV2(any(TransferRequest.class), any());
+        doThrow(TransferException.class).when(client).updateAgreement(any(UpdateAgreementRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -218,8 +195,6 @@ public class UpdateHandlerTest {
                 .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        assertThrows(CfnGeneralServiceException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnGeneralServiceException.class, () -> callHandler(request));
     }
 }

--- a/aws-transfer-certificate/spotbugs-exclude.xml
+++ b/aws-transfer-certificate/spotbugs-exclude.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <Match>
+        <Class name="software.amazon.transfer.certificate.HandlerWrapperExecutable"/>
+    </Match>
+    <Match>
+        <Class name="software.amazon.transfer.certificate.HandlerWrapper"/>
+    </Match>
+    <Match>
+        <Class name="software.amazon.transfer.certificate.ResourceModel"/>
+    </Match>
+    <Match>
+        <Bug code="RCN,EI,EI2"/>
+    </Match>
+</FindBugsFilter>

--- a/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/BaseHandlerStd.java
+++ b/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/BaseHandlerStd.java
@@ -1,0 +1,40 @@
+package software.amazon.transfer.certificate;
+
+import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+/**
+ * The purpose of this base class is to allow a simple calling pattern that
+ * makes testing Uluru handlers easier and avoids having to store context
+ * in class fields. The {@link MockableBaseHandler} interface is used to
+ * make isolation of the inner call such that in testing we guarantee that
+ * the caller will not pick the wrong method and avoid human error.
+ */
+public abstract class BaseHandlerStd extends BaseHandler<CallbackContext>
+        implements MockableBaseHandler<CallbackContext> {
+    @Override
+    public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final Logger logger) {
+        return handleRequest(
+                proxy,
+                request,
+                callbackContext != null ? callbackContext : new CallbackContext(),
+                proxy.newProxy(ClientBuilder::getClient),
+                logger);
+    }
+
+    @Override
+    public abstract ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
+            final Logger logger);
+}

--- a/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/CreateHandler.java
+++ b/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/CreateHandler.java
@@ -22,6 +22,7 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.amazonaws.util.CollectionUtils;
@@ -29,23 +30,14 @@ import com.amazonaws.util.CollectionUtils;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class CreateHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public CreateHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class CreateHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         ResourceModel model = request.getDesiredResourceState();
 
@@ -79,7 +71,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                                         .map(Converter.TagConverter::toSdk)
                                         .collect(Collectors.toList()))
                 .build();
-        try {
+        try (TransferClient client = proxyClient.client()) {
             ImportCertificateResponse response =
                     proxy.injectCredentialsAndInvokeV2(importCertificateRequest, client::importCertificate);
             model.setCertificateId(response.certificateId());

--- a/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/DeleteHandler.java
+++ b/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/DeleteHandler.java
@@ -14,35 +14,27 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class DeleteHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public DeleteHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class DeleteHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         final ResourceModel model = request.getDesiredResourceState();
 
         final DeleteCertificateRequest deleteCertificateRequest = DeleteCertificateRequest.builder()
                 .certificateId(model.getCertificateId())
                 .build();
-        try {
+        try (TransferClient client = proxyClient.client()) {
             proxy.injectCredentialsAndInvokeV2(deleteCertificateRequest, client::deleteCertificate);
             logger.log(
                     String.format("%s %s deleted successfully", ResourceModel.TYPE_NAME, model.getPrimaryIdentifier()));

--- a/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/ListHandler.java
+++ b/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/ListHandler.java
@@ -16,28 +16,20 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class ListHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public ListHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class ListHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         List<ResourceModel> models = new ArrayList<>();
 
@@ -46,7 +38,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
                 .nextToken(request.getNextToken())
                 .build();
 
-        try {
+        try (TransferClient client = proxyClient.client()) {
             ListCertificatesResponse response =
                     proxy.injectCredentialsAndInvokeV2(listCertificatesRequest, client::listCertificates);
 

--- a/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/MockableBaseHandler.java
+++ b/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/MockableBaseHandler.java
@@ -1,0 +1,24 @@
+package software.amazon.transfer.certificate;
+
+import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+/**
+ * Interface exposing the only handler method that should be used when
+ * testing Uluru handlers. This provides a mechanism to feed the call chain
+ * a mock client as needed without complex static mocking of the ClientBuilder.
+ *
+ * @param <CallbackT>
+ */
+interface MockableBaseHandler<CallbackT> {
+    ProgressEvent<ResourceModel, CallbackT> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackT callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
+            final Logger logger);
+}

--- a/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/ReadHandler.java
+++ b/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/ReadHandler.java
@@ -18,6 +18,7 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.amazonaws.util.CollectionUtils;
@@ -25,30 +26,21 @@ import com.amazonaws.util.CollectionUtils;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class ReadHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public ReadHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class ReadHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         final ResourceModel model = request.getDesiredResourceState();
 
         DescribeCertificateRequest describeCertificateRequest = DescribeCertificateRequest.builder()
                 .certificateId(model.getCertificateId())
                 .build();
-        try {
+        try (TransferClient client = proxyClient.client()) {
             DescribeCertificateResponse response =
                     proxy.injectCredentialsAndInvokeV2(describeCertificateRequest, client::describeCertificate);
             logger.log(String.format(

--- a/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/UpdateHandler.java
+++ b/aws-transfer-certificate/src/main/java/software/amazon/transfer/certificate/UpdateHandler.java
@@ -25,28 +25,21 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class UpdateHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public UpdateHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class UpdateHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
 
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
         final ResourceModel model = request.getDesiredResourceState();
 
         UpdateCertificateRequest updateCertificateRequest = UpdateCertificateRequest.builder()
@@ -75,7 +68,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         Set<Tag> tagsToAdd = Sets.difference(new HashSet<>(desiredTags), new HashSet<>(previousTags));
         Set<Tag> tagsToRemove = Sets.difference(new HashSet<>(previousTags), new HashSet<>(desiredTags));
 
-        try {
+        try (TransferClient client = proxyClient.client()) {
             proxy.injectCredentialsAndInvokeV2(updateCertificateRequest, client::updateCertificate);
             logger.log(String.format("%s created successfully", ResourceModel.TYPE_NAME));
 

--- a/aws-transfer-certificate/src/test/java/software/amazon/transfer/certificate/AbstractTestBase.java
+++ b/aws-transfer-certificate/src/test/java/software/amazon/transfer/certificate/AbstractTestBase.java
@@ -1,15 +1,34 @@
 package software.amazon.transfer.certificate;
 
+import static org.mockito.Mockito.mock;
+
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-public class AbstractTestBase {
-    private AbstractTestBase() {}
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
 
+import software.amazon.awssdk.awscore.AwsRequest;
+import software.amazon.awssdk.awscore.AwsResponse;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Credentials;
+import software.amazon.cloudformation.proxy.LoggerProxy;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+public abstract class AbstractTestBase {
     public static final String TEST_CERTIFICATE_ID = "id";
     public static final String TEST_ARN = "arn:certificate";
     public static final String TEST_DESCRIPTION = "description";
@@ -20,21 +39,96 @@ public class AbstractTestBase {
     public static final String TEST_PRIVATE_KEY = "private-key";
     public static final String TEST_ACTIVE_DATE = "2022-07-17T09:59:51.312Z";
     public static final String TEST_INACTIVE_DATE = "2069-07-17T09:59:51.312Z";
-    public static Map<String, String> RESOURCE_TAG_MAP = Collections.singletonMap("key", "value");
-    public static Map<String, String> SYSTEM_TAG_MAP =
+    public static final Map<String, String> RESOURCE_TAG_MAP = Collections.singletonMap("key", "value");
+    public static final Map<String, String> SYSTEM_TAG_MAP =
             Collections.singletonMap("aws:cloudformation:stack-name", "StackName");
-    public static Map<String, String> TEST_TAG_MAP =
+    public static final Map<String, String> TEST_TAG_MAP =
             ImmutableMap.of("key", "value", "aws:cloudformation:stack-name", "StackName");
-    public static Set<Tag> MODEL_TAGS =
+    public static final Set<Tag> MODEL_TAGS =
             ImmutableSet.of(Tag.builder().key("key").value("value").build());
-    public static software.amazon.awssdk.services.transfer.model.Tag SDK_MODEL_TAG =
+    public static final software.amazon.awssdk.services.transfer.model.Tag SDK_MODEL_TAG =
             software.amazon.awssdk.services.transfer.model.Tag.builder()
                     .key("key")
                     .value("value")
                     .build();
-    public static software.amazon.awssdk.services.transfer.model.Tag SDK_SYSTEM_TAG =
+    public static final software.amazon.awssdk.services.transfer.model.Tag SDK_SYSTEM_TAG =
             software.amazon.awssdk.services.transfer.model.Tag.builder()
                     .key("aws:cloudformation:stack-name")
                     .value("StackName")
                     .build();
+
+    abstract MockableBaseHandler<CallbackContext> getHandler();
+
+    protected ProgressEvent<ResourceModel, CallbackContext> callHandler(ResourceHandlerRequest<ResourceModel> request) {
+        return getHandler().handleRequest(proxy, request, null, proxyClient, logger);
+    }
+
+    protected static final Credentials MOCK_CREDENTIALS;
+    protected static final LoggerProxy logger;
+
+    static {
+        MOCK_CREDENTIALS = new Credentials("accessKey", "secretKey", "token");
+        logger = new LoggerProxy();
+    }
+
+    protected AmazonWebServicesClientProxy proxy;
+
+    protected ProxyClient<TransferClient> proxyClient;
+
+    @Mock
+    protected TransferClient client;
+
+    @BeforeEach
+    public void setup() {
+        proxy = new AmazonWebServicesClientProxy(
+                logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
+        client = mock(TransferClient.class);
+        proxyClient = MOCK_PROXY(proxy, client);
+    }
+
+    static <T> ProxyClient<T> MOCK_PROXY(final AmazonWebServicesClientProxy proxy, final T sdkClient) {
+        return new ProxyClient<T>() {
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseT injectCredentialsAndInvokeV2(
+                    RequestT request, Function<RequestT, ResponseT> requestFunction) {
+                return proxy.injectCredentialsAndInvokeV2(request, requestFunction);
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+                    CompletableFuture<ResponseT> injectCredentialsAndInvokeV2Async(
+                            RequestT request, Function<RequestT, CompletableFuture<ResponseT>> requestFunction) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <
+                            RequestT extends AwsRequest,
+                            ResponseT extends AwsResponse,
+                            IterableT extends SdkIterable<ResponseT>>
+                    IterableT injectCredentialsAndInvokeIterableV2(
+                            RequestT request, Function<RequestT, IterableT> requestFunction) {
+                return proxy.injectCredentialsAndInvokeIterableV2(request, requestFunction);
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+                    ResponseInputStream<ResponseT> injectCredentialsAndInvokeV2InputStream(
+                            RequestT requestT, Function<RequestT, ResponseInputStream<ResponseT>> function) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+                    ResponseBytes<ResponseT> injectCredentialsAndInvokeV2Bytes(
+                            RequestT requestT, Function<RequestT, ResponseBytes<ResponseT>> function) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public T client() {
+                return sdkClient;
+            }
+        };
+    }
 }

--- a/aws-transfer-certificate/src/test/java/software/amazon/transfer/certificate/BaseHandlerStdTest.java
+++ b/aws-transfer-certificate/src/test/java/software/amazon/transfer/certificate/BaseHandlerStdTest.java
@@ -1,0 +1,56 @@
+package software.amazon.transfer.certificate;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+@ExtendWith(MockitoExtension.class)
+public class BaseHandlerStdTest {
+    @Mock
+    private AmazonWebServicesClientProxy proxy;
+
+    static class MockTestHandler extends BaseHandlerStd {
+        @Override
+        public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+                AmazonWebServicesClientProxy proxy,
+                ResourceHandlerRequest<ResourceModel> request,
+                CallbackContext callbackContext,
+                ProxyClient<TransferClient> proxyClient,
+                Logger logger) {
+            assertNotNull(callbackContext);
+            return null;
+        }
+    }
+
+    @Test
+    void justToCover3LinesOfCode() {
+        var uut = new MockTestHandler();
+
+        // Check with null CallbackContext
+        uut.handleRequest(proxy, null, null, null);
+        verify(proxy, times(1)).newProxy(any());
+        verifyNoMoreInteractions(proxy);
+        reset(proxy);
+
+        // Check with non-null CallbackContext
+        uut.handleRequest(proxy, null, new CallbackContext(), null);
+        verify(proxy, times(1)).newProxy(any());
+        verifyNoMoreInteractions(proxy);
+        reset(proxy);
+    }
+}

--- a/aws-transfer-certificate/src/test/java/software/amazon/transfer/certificate/DeleteHandlerTest.java
+++ b/aws-transfer-certificate/src/test/java/software/amazon/transfer/certificate/DeleteHandlerTest.java
@@ -6,12 +6,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static software.amazon.transfer.certificate.AbstractTestBase.*;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.awssdk.services.transfer.model.DeleteCertificateRequest;
 import software.amazon.awssdk.services.transfer.model.InternalServiceErrorException;
 import software.amazon.awssdk.services.transfer.model.InvalidRequestException;
 import software.amazon.awssdk.services.transfer.model.ResourceNotFoundException;
@@ -20,28 +20,27 @@ import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 @ExtendWith(MockitoExtension.class)
-public class DeleteHandlerTest {
+public class DeleteHandlerTest extends AbstractTestBase {
 
-    @Mock
-    private AmazonWebServicesClientProxy proxy;
+    private MockableBaseHandler<CallbackContext> handler;
 
-    @Mock
-    private Logger logger;
+    @Override
+    MockableBaseHandler<CallbackContext> getHandler() {
+        return handler;
+    }
 
-    @Mock
-    private TransferClient client;
+    @BeforeEach
+    public void setupTestData() {
+        handler = new DeleteHandler();
+    }
 
     @Test
     public void handleRequest_SimpleSuccess() {
-        final DeleteHandler handler = new DeleteHandler(client);
-
         final ResourceModel model =
                 ResourceModel.builder().certificateId(TEST_CERTIFICATE_ID).build();
 
@@ -49,8 +48,7 @@ public class DeleteHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        final ProgressEvent<ResourceModel, CallbackContext> response =
-                handler.handleRequest(proxy, request, null, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = callHandler(request);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -63,9 +61,7 @@ public class DeleteHandlerTest {
 
     @Test
     public void handleRequest_InvalidRequestExceptionFailed() {
-        DeleteHandler handler = new DeleteHandler(client);
-
-        doThrow(InvalidRequestException.class).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doThrow(InvalidRequestException.class).when(client).deleteCertificate(any(DeleteCertificateRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -73,16 +69,14 @@ public class DeleteHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnInvalidRequestException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnInvalidRequestException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_InternalServiceErrorExceptionFailed() {
-        DeleteHandler handler = new DeleteHandler(client);
-
-        doThrow(InternalServiceErrorException.class).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doThrow(InternalServiceErrorException.class)
+                .when(client)
+                .deleteCertificate(any(DeleteCertificateRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -90,16 +84,12 @@ public class DeleteHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnServiceInternalErrorException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnServiceInternalErrorException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_ResourceNotFoundExceptionFailed() {
-        DeleteHandler handler = new DeleteHandler(client);
-
-        doThrow(ResourceNotFoundException.class).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doThrow(ResourceNotFoundException.class).when(client).deleteCertificate(any(DeleteCertificateRequest.class));
 
         ResourceModel model =
                 ResourceModel.builder().certificateId(TEST_CERTIFICATE_ID).build();
@@ -108,16 +98,12 @@ public class DeleteHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnNotFoundException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnNotFoundException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_TransferExceptionFailed() {
-        DeleteHandler handler = new DeleteHandler(client);
-
-        doThrow(TransferException.class).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doThrow(TransferException.class).when(client).deleteCertificate(any(DeleteCertificateRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -125,8 +111,6 @@ public class DeleteHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnGeneralServiceException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnGeneralServiceException.class, () -> callHandler(request));
     }
 }

--- a/aws-transfer-certificate/src/test/java/software/amazon/transfer/certificate/ListHandlerTest.java
+++ b/aws-transfer-certificate/src/test/java/software/amazon/transfer/certificate/ListHandlerTest.java
@@ -9,42 +9,41 @@ import static software.amazon.transfer.certificate.AbstractTestBase.*;
 
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import software.amazon.awssdk.services.transfer.TransferClient;
 import software.amazon.awssdk.services.transfer.model.InternalServiceErrorException;
 import software.amazon.awssdk.services.transfer.model.InvalidRequestException;
+import software.amazon.awssdk.services.transfer.model.ListCertificatesRequest;
 import software.amazon.awssdk.services.transfer.model.ListCertificatesResponse;
 import software.amazon.awssdk.services.transfer.model.ListedCertificate;
 import software.amazon.awssdk.services.transfer.model.TransferException;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 @ExtendWith(MockitoExtension.class)
-public class ListHandlerTest {
+public class ListHandlerTest extends AbstractTestBase {
 
-    @Mock
-    private AmazonWebServicesClientProxy proxy;
+    private MockableBaseHandler<CallbackContext> handler;
 
-    @Mock
-    private Logger logger;
+    @Override
+    MockableBaseHandler<CallbackContext> getHandler() {
+        return handler;
+    }
 
-    @Mock
-    private TransferClient client;
+    @BeforeEach
+    public void setupTestData() {
+        handler = new ListHandler();
+    }
 
     @Test
     public void handleRequest_SimpleSuccess() {
-        final ListHandler handler = new ListHandler(client);
-
         ListedCertificate listedCertificate = ListedCertificate.builder()
                 .description(TEST_DESCRIPTION)
                 .arn(TEST_ARN)
@@ -61,10 +60,9 @@ public class ListHandlerTest {
         ListCertificatesResponse listCertificatesResponse = ListCertificatesResponse.builder()
                 .certificates(listedCertificate)
                 .build();
-        doReturn(listCertificatesResponse).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doReturn(listCertificatesResponse).when(client).listCertificates(any(ListCertificatesRequest.class));
 
-        final ProgressEvent<ResourceModel, CallbackContext> response =
-                handler.handleRequest(proxy, request, null, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = callHandler(request);
 
         List<ResourceModel> testModels = response.getResourceModels();
 
@@ -86,9 +84,7 @@ public class ListHandlerTest {
 
     @Test
     public void handleRequest_InvalidRequestExceptionFailed() {
-        ListHandler handler = new ListHandler(client);
-
-        doThrow(InvalidRequestException.class).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doThrow(InvalidRequestException.class).when(client).listCertificates(any(ListCertificatesRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -96,16 +92,12 @@ public class ListHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnInvalidRequestException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnInvalidRequestException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_InternalServiceErrorExceptionFailed() {
-        ListHandler handler = new ListHandler(client);
-
-        doThrow(InternalServiceErrorException.class).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doThrow(InternalServiceErrorException.class).when(client).listCertificates(any(ListCertificatesRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -113,16 +105,12 @@ public class ListHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnServiceInternalErrorException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnServiceInternalErrorException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_TransferExceptionFailed() {
-        ListHandler handler = new ListHandler(client);
-
-        doThrow(TransferException.class).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doThrow(TransferException.class).when(client).listCertificates(any(ListCertificatesRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -130,8 +118,6 @@ public class ListHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnGeneralServiceException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnGeneralServiceException.class, () -> callHandler(request));
     }
 }

--- a/aws-transfer-certificate/src/test/java/software/amazon/transfer/certificate/ReadHandlerTest.java
+++ b/aws-transfer-certificate/src/test/java/software/amazon/transfer/certificate/ReadHandlerTest.java
@@ -7,12 +7,12 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static software.amazon.transfer.certificate.AbstractTestBase.*;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.awssdk.services.transfer.model.DescribeCertificateRequest;
 import software.amazon.awssdk.services.transfer.model.DescribeCertificateResponse;
 import software.amazon.awssdk.services.transfer.model.DescribedCertificate;
 import software.amazon.awssdk.services.transfer.model.InternalServiceErrorException;
@@ -23,28 +23,27 @@ import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 @ExtendWith(MockitoExtension.class)
-public class ReadHandlerTest {
+public class ReadHandlerTest extends AbstractTestBase {
 
-    @Mock
-    private AmazonWebServicesClientProxy proxy;
+    private MockableBaseHandler<CallbackContext> handler;
 
-    @Mock
-    private Logger logger;
+    @Override
+    MockableBaseHandler<CallbackContext> getHandler() {
+        return handler;
+    }
 
-    @Mock
-    private TransferClient client;
+    @BeforeEach
+    public void setupTestData() {
+        handler = new ReadHandler();
+    }
 
     @Test
     public void handleRequest_SimpleSuccess() {
-        final ReadHandler handler = new ReadHandler(client);
-
         final ResourceModel model =
                 ResourceModel.builder().certificateId(TEST_CERTIFICATE_ID).build();
 
@@ -57,10 +56,9 @@ public class ReadHandlerTest {
                         .description(TEST_DESCRIPTION)
                         .build())
                 .build();
-        doReturn(describeCertificateResponse).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doReturn(describeCertificateResponse).when(client).describeCertificate(any(DescribeCertificateRequest.class));
 
-        final ProgressEvent<ResourceModel, CallbackContext> response =
-                handler.handleRequest(proxy, request, null, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = callHandler(request);
         ResourceModel testModel = response.getResourceModel();
 
         assertThat(response).isNotNull();
@@ -75,9 +73,7 @@ public class ReadHandlerTest {
 
     @Test
     public void handleRequest_InvalidRequestExceptionFailed() {
-        ReadHandler handler = new ReadHandler(client);
-
-        doThrow(InvalidRequestException.class).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doThrow(InvalidRequestException.class).when(client).describeCertificate(any(DescribeCertificateRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -85,16 +81,14 @@ public class ReadHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnInvalidRequestException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnInvalidRequestException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_InternalServiceErrorExceptionFailed() {
-        ReadHandler handler = new ReadHandler(client);
-
-        doThrow(InternalServiceErrorException.class).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doThrow(InternalServiceErrorException.class)
+                .when(client)
+                .describeCertificate(any(DescribeCertificateRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -102,16 +96,14 @@ public class ReadHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnServiceInternalErrorException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnServiceInternalErrorException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_ResourceNotFoundExceptionFailed() {
-        ReadHandler handler = new ReadHandler(client);
-
-        doThrow(ResourceNotFoundException.class).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doThrow(ResourceNotFoundException.class)
+                .when(client)
+                .describeCertificate(any(DescribeCertificateRequest.class));
 
         ResourceModel model =
                 ResourceModel.builder().certificateId(TEST_CERTIFICATE_ID).build();
@@ -120,16 +112,12 @@ public class ReadHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnNotFoundException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnNotFoundException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_TransferExceptionFailed() {
-        ReadHandler handler = new ReadHandler(client);
-
-        doThrow(TransferException.class).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doThrow(TransferException.class).when(client).describeCertificate(any(DescribeCertificateRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -137,8 +125,6 @@ public class ReadHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnGeneralServiceException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnGeneralServiceException.class, () -> callHandler(request));
     }
 }

--- a/aws-transfer-connector/spotbugs-exclude.xml
+++ b/aws-transfer-connector/spotbugs-exclude.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <Match>
+        <Class name="software.amazon.transfer.connector.HandlerWrapperExecutable"/>
+    </Match>
+    <Match>
+        <Class name="software.amazon.transfer.connector.HandlerWrapper"/>
+    </Match>
+    <Match>
+        <Class name="software.amazon.transfer.connector.ResourceModel"/>
+    </Match>
+    <Match>
+        <Bug code="RCN,EI,EI2"/>
+    </Match>
+</FindBugsFilter>

--- a/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/BaseHandlerStd.java
+++ b/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/BaseHandlerStd.java
@@ -1,0 +1,40 @@
+package software.amazon.transfer.connector;
+
+import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+/**
+ * The purpose of this base class is to allow a simple calling pattern that
+ * makes testing Uluru handlers easier and avoids having to store context
+ * in class fields. The {@link MockableBaseHandler} interface is used to
+ * make isolation of the inner call such that in testing we guarantee that
+ * the caller will not pick the wrong method and avoid human error.
+ */
+public abstract class BaseHandlerStd extends BaseHandler<CallbackContext>
+        implements MockableBaseHandler<CallbackContext> {
+    @Override
+    public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final Logger logger) {
+        return handleRequest(
+                proxy,
+                request,
+                callbackContext != null ? callbackContext : new CallbackContext(),
+                proxy.newProxy(ClientBuilder::getClient),
+                logger);
+    }
+
+    @Override
+    public abstract ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
+            final Logger logger);
+}

--- a/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/CreateHandler.java
+++ b/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/CreateHandler.java
@@ -21,6 +21,7 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.amazonaws.util.CollectionUtils;
@@ -28,23 +29,14 @@ import com.amazonaws.util.CollectionUtils;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class CreateHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public CreateHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class CreateHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         final ResourceModel model = request.getDesiredResourceState();
 
@@ -75,7 +67,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                                         .collect(Collectors.toList()))
                 .build();
 
-        try {
+        try (TransferClient client = proxyClient.client()) {
             CreateConnectorResponse response =
                     proxy.injectCredentialsAndInvokeV2(createConnectorRequest, client::createConnector);
             model.setConnectorId(response.connectorId());

--- a/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/DeleteHandler.java
+++ b/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/DeleteHandler.java
@@ -14,28 +14,20 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class DeleteHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public DeleteHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class DeleteHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         final ResourceModel model = request.getDesiredResourceState();
 
@@ -43,7 +35,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
                 .connectorId(model.getConnectorId())
                 .build();
 
-        try {
+        try (TransferClient client = proxyClient.client()) {
             proxy.injectCredentialsAndInvokeV2(deleteConnectorRequest, client::deleteConnector);
             logger.log(
                     String.format("%s %s deleted successfully", ResourceModel.TYPE_NAME, model.getPrimaryIdentifier()));

--- a/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/ListHandler.java
+++ b/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/ListHandler.java
@@ -16,28 +16,20 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class ListHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public ListHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class ListHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         final List<ResourceModel> models = new ArrayList<>();
 
@@ -46,7 +38,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
                 .nextToken(request.getNextToken())
                 .build();
 
-        try {
+        try (TransferClient client = proxyClient.client()) {
             ListConnectorsResponse response =
                     proxy.injectCredentialsAndInvokeV2(listConnectorsRequest, client::listConnectors);
 

--- a/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/MockableBaseHandler.java
+++ b/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/MockableBaseHandler.java
@@ -1,0 +1,24 @@
+package software.amazon.transfer.connector;
+
+import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+/**
+ * Interface exposing the only handler method that should be used when
+ * testing Uluru handlers. This provides a mechanism to feed the call chain
+ * a mock client as needed without complex static mocking of the ClientBuilder.
+ *
+ * @param <CallbackT>
+ */
+interface MockableBaseHandler<CallbackT> {
+    ProgressEvent<ResourceModel, CallbackT> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackT callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
+            final Logger logger);
+}

--- a/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/ReadHandler.java
+++ b/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/ReadHandler.java
@@ -18,6 +18,7 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.amazonaws.util.CollectionUtils;
@@ -25,30 +26,21 @@ import com.amazonaws.util.CollectionUtils;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class ReadHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public ReadHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class ReadHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         final ResourceModel model = request.getDesiredResourceState();
         DescribeConnectorRequest describeConnectorRequest = DescribeConnectorRequest.builder()
                 .connectorId(model.getConnectorId())
                 .build();
 
-        try {
+        try (TransferClient client = proxyClient.client()) {
             DescribeConnectorResponse response =
                     proxy.injectCredentialsAndInvokeV2(describeConnectorRequest, client::describeConnector);
             logger.log(String.format(

--- a/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/UpdateHandler.java
+++ b/aws-transfer-connector/src/main/java/software/amazon/transfer/connector/UpdateHandler.java
@@ -24,28 +24,20 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class UpdateHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public UpdateHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class UpdateHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         final ResourceModel model = request.getDesiredResourceState();
         String arn = String.format(
@@ -76,7 +68,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         Set<Tag> tagsToAdd = Sets.difference(new HashSet<>(desiredTags), new HashSet<>(previousTags));
         Set<Tag> tagsToRemove = Sets.difference(new HashSet<>(previousTags), new HashSet<>(desiredTags));
 
-        try {
+        try (TransferClient client = proxyClient.client()) {
             proxy.injectCredentialsAndInvokeV2(updateConnectorRequest, client::updateConnector);
             logger.log(String.format("%s updated successfully", ResourceModel.TYPE_NAME));
 

--- a/aws-transfer-connector/src/test/java/software/amazon/transfer/connector/AbstractTestBase.java
+++ b/aws-transfer-connector/src/test/java/software/amazon/transfer/connector/AbstractTestBase.java
@@ -1,42 +1,64 @@
 package software.amazon.transfer.connector;
 
+import static org.mockito.Mockito.mock;
+
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-public class AbstractTestBase {
-    public static String TEST_ARN = "arn:test-arn";
-    public static String TEST_ACCESS_ROLE = "access-role";
-    public static String TEST_LOGGING_ROLE = "logging-role";
-    public static String TEST_URL = "http://test.com/";
-    public static String TEST_CONNECTOR_ID = "c-123456789";
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
 
-    public static String TEST_LOCAL_PROFILE = "local-profile";
-    public static String TEST_PARTNER_PROFILE = "partner-profile";
-    public static String TEST_MESSAGE_SUBJECT = "This is a test message subject.";
-    public static String TEST_COMPRESSION = "ZLIB";
-    public static String TEST_ENCRYPTION_ALGORITHM = "AES128_CBC";
-    public static String TEST_SIGNING_ALGORITHM = "SHA256";
-    public static String TEST_MDN_SIGNING_ALGORITHM = "SHA256";
-    public static String TEST_MDN_RESPONSE = "SYNC";
-    public static String TEST_BASIC_AUTH_SECRET = "basic-auth-secret";
-    public static String TEST_USER_SECRET_ID = "arn:aws:secretsmanager:us-east-1:123456789:secret:testest";
-    public static Map<String, String> RESOURCE_TAG_MAP = Collections.singletonMap("key", "value");
-    public static Map<String, String> SYSTEM_TAG_MAP =
+import software.amazon.awssdk.awscore.AwsRequest;
+import software.amazon.awssdk.awscore.AwsResponse;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Credentials;
+import software.amazon.cloudformation.proxy.LoggerProxy;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+public abstract class AbstractTestBase {
+    public static final String TEST_ARN = "arn:test-arn";
+    public static final String TEST_ACCESS_ROLE = "access-role";
+    public static final String TEST_LOGGING_ROLE = "logging-role";
+    public static final String TEST_URL = "http://test.com/";
+    public static final String TEST_CONNECTOR_ID = "c-123456789";
+
+    public static final String TEST_LOCAL_PROFILE = "local-profile";
+    public static final String TEST_PARTNER_PROFILE = "partner-profile";
+    public static final String TEST_MESSAGE_SUBJECT = "This is a test message subject.";
+    public static final String TEST_COMPRESSION = "ZLIB";
+    public static final String TEST_ENCRYPTION_ALGORITHM = "AES128_CBC";
+    public static final String TEST_SIGNING_ALGORITHM = "SHA256";
+    public static final String TEST_MDN_SIGNING_ALGORITHM = "SHA256";
+    public static final String TEST_MDN_RESPONSE = "SYNC";
+    public static final String TEST_BASIC_AUTH_SECRET = "basic-auth-secret";
+    public static final String TEST_USER_SECRET_ID = "arn:aws:secretsmanager:us-east-1:123456789:secret:testest";
+    public static final String TEST_SECURITY_POLICY_NAME = "TransferSFTPConnectorSecurityPolicy-2023-07";
+    public static final Map<String, String> RESOURCE_TAG_MAP = Collections.singletonMap("key", "value");
+    public static final Map<String, String> SYSTEM_TAG_MAP =
             Collections.singletonMap("aws:cloudformation:stack-name", "StackName");
-    public static Map<String, String> TEST_TAG_MAP =
+    public static final Map<String, String> TEST_TAG_MAP =
             ImmutableMap.of("key", "value", "aws:cloudformation:stack-name", "StackName");
-    public static Set<Tag> MODEL_TAGS =
+    public static final Set<Tag> MODEL_TAGS =
             ImmutableSet.of(Tag.builder().key("key").value("value").build());
-    public static software.amazon.awssdk.services.transfer.model.Tag SDK_MODEL_TAG =
+    public static final software.amazon.awssdk.services.transfer.model.Tag SDK_MODEL_TAG =
             software.amazon.awssdk.services.transfer.model.Tag.builder()
                     .key("key")
                     .value("value")
                     .build();
-    public static software.amazon.awssdk.services.transfer.model.Tag SDK_SYSTEM_TAG =
+    public static final software.amazon.awssdk.services.transfer.model.Tag SDK_SYSTEM_TAG =
             software.amazon.awssdk.services.transfer.model.Tag.builder()
                     .key("aws:cloudformation:stack-name")
                     .value("StackName")
@@ -61,5 +83,80 @@ public class AbstractTestBase {
                 .userSecretId(TEST_USER_SECRET_ID)
                 .trustedHostKeys(Collections.emptyList())
                 .build();
+    }
+
+    abstract MockableBaseHandler<CallbackContext> getHandler();
+
+    protected ProgressEvent<ResourceModel, CallbackContext> callHandler(ResourceHandlerRequest<ResourceModel> request) {
+        return getHandler().handleRequest(proxy, request, null, proxyClient, logger);
+    }
+
+    protected static final Credentials MOCK_CREDENTIALS;
+    protected static final LoggerProxy logger;
+
+    static {
+        MOCK_CREDENTIALS = new Credentials("accessKey", "secretKey", "token");
+        logger = new LoggerProxy();
+    }
+
+    protected AmazonWebServicesClientProxy proxy;
+
+    protected ProxyClient<TransferClient> proxyClient;
+
+    @Mock
+    protected TransferClient client;
+
+    @BeforeEach
+    public void setup() {
+        proxy = new AmazonWebServicesClientProxy(
+                logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
+        client = mock(TransferClient.class);
+        proxyClient = MOCK_PROXY(proxy, client);
+    }
+
+    static <T> ProxyClient<T> MOCK_PROXY(final AmazonWebServicesClientProxy proxy, final T sdkClient) {
+        return new ProxyClient<T>() {
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseT injectCredentialsAndInvokeV2(
+                    RequestT request, Function<RequestT, ResponseT> requestFunction) {
+                return proxy.injectCredentialsAndInvokeV2(request, requestFunction);
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+                    CompletableFuture<ResponseT> injectCredentialsAndInvokeV2Async(
+                            RequestT request, Function<RequestT, CompletableFuture<ResponseT>> requestFunction) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <
+                            RequestT extends AwsRequest,
+                            ResponseT extends AwsResponse,
+                            IterableT extends SdkIterable<ResponseT>>
+                    IterableT injectCredentialsAndInvokeIterableV2(
+                            RequestT request, Function<RequestT, IterableT> requestFunction) {
+                return proxy.injectCredentialsAndInvokeIterableV2(request, requestFunction);
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+                    ResponseInputStream<ResponseT> injectCredentialsAndInvokeV2InputStream(
+                            RequestT requestT, Function<RequestT, ResponseInputStream<ResponseT>> function) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+                    ResponseBytes<ResponseT> injectCredentialsAndInvokeV2Bytes(
+                            RequestT requestT, Function<RequestT, ResponseBytes<ResponseT>> function) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public T client() {
+                return sdkClient;
+            }
+        };
     }
 }

--- a/aws-transfer-connector/src/test/java/software/amazon/transfer/connector/BaseHandlerStdTest.java
+++ b/aws-transfer-connector/src/test/java/software/amazon/transfer/connector/BaseHandlerStdTest.java
@@ -1,0 +1,56 @@
+package software.amazon.transfer.connector;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+@ExtendWith(MockitoExtension.class)
+public class BaseHandlerStdTest {
+    @Mock
+    private AmazonWebServicesClientProxy proxy;
+
+    static class MockTestHandler extends BaseHandlerStd {
+        @Override
+        public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+                AmazonWebServicesClientProxy proxy,
+                ResourceHandlerRequest<ResourceModel> request,
+                CallbackContext callbackContext,
+                ProxyClient<TransferClient> proxyClient,
+                Logger logger) {
+            assertNotNull(callbackContext);
+            return null;
+        }
+    }
+
+    @Test
+    void justToCover3LinesOfCode() {
+        var uut = new MockTestHandler();
+
+        // Check with null CallbackContext
+        uut.handleRequest(proxy, null, null, null);
+        verify(proxy, times(1)).newProxy(any());
+        verifyNoMoreInteractions(proxy);
+        reset(proxy);
+
+        // Check with non-null CallbackContext
+        uut.handleRequest(proxy, null, new CallbackContext(), null);
+        verify(proxy, times(1)).newProxy(any());
+        verifyNoMoreInteractions(proxy);
+        reset(proxy);
+    }
+}

--- a/aws-transfer-connector/src/test/java/software/amazon/transfer/connector/CreateHandlerTest.java
+++ b/aws-transfer-connector/src/test/java/software/amazon/transfer/connector/CreateHandlerTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static software.amazon.transfer.connector.AbstractTestBase.*;
 
@@ -13,10 +12,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import software.amazon.awssdk.services.transfer.TransferClient;
 import software.amazon.awssdk.services.transfer.model.CreateConnectorRequest;
 import software.amazon.awssdk.services.transfer.model.CreateConnectorResponse;
 import software.amazon.awssdk.services.transfer.model.InternalServiceErrorException;
@@ -29,34 +26,27 @@ import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
 import software.amazon.cloudformation.exceptions.CfnThrottlingException;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 @ExtendWith(MockitoExtension.class)
-public class CreateHandlerTest {
+public class CreateHandlerTest extends AbstractTestBase {
 
-    @Mock
-    private AmazonWebServicesClientProxy proxy;
+    private MockableBaseHandler<CallbackContext> handler;
 
-    @Mock
-    private Logger logger;
-
-    @Mock
-    private TransferClient client;
+    @Override
+    MockableBaseHandler<CallbackContext> getHandler() {
+        return handler;
+    }
 
     @BeforeEach
-    public void setup() {
-        proxy = mock(AmazonWebServicesClientProxy.class);
-        logger = mock(Logger.class);
+    public void setupTestData() {
+        handler = new CreateHandler();
     }
 
     @Test
     public void handleRequest_SimpleSuccess() {
-        final CreateHandler handler = new CreateHandler(client);
-
         final ResourceModel model = ResourceModel.builder()
                 .accessRole(TEST_ACCESS_ROLE)
                 .as2Config(getAs2Config())
@@ -75,10 +65,9 @@ public class CreateHandlerTest {
         CreateConnectorResponse createConnectorResponse =
                 CreateConnectorResponse.builder().connectorId(TEST_CONNECTOR_ID).build();
 
-        doReturn(createConnectorResponse).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doReturn(createConnectorResponse).when(client).createConnector(any(CreateConnectorRequest.class));
 
-        final ProgressEvent<ResourceModel, CallbackContext> response =
-                handler.handleRequest(proxy, request, null, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = callHandler(request);
 
         ResourceModel testModel = response.getResourceModel();
         assertThat(response).isNotNull();
@@ -96,18 +85,14 @@ public class CreateHandlerTest {
         assertThat(testModel).hasFieldOrPropertyWithValue("url", TEST_URL);
 
         ArgumentCaptor<CreateConnectorRequest> requestCaptor = ArgumentCaptor.forClass(CreateConnectorRequest.class);
-        verify(proxy).injectCredentialsAndInvokeV2(requestCaptor.capture(), any());
+        verify(client).createConnector(requestCaptor.capture());
         CreateConnectorRequest actualRequest = requestCaptor.getValue();
         assertThat(actualRequest.tags()).containsExactlyInAnyOrder(SDK_MODEL_TAG, SDK_SYSTEM_TAG);
     }
 
     @Test
     public void handleRequest_InvalidRequestExceptionFailed() {
-        CreateHandler handler = new CreateHandler(client);
-
-        doThrow(InvalidRequestException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(CreateConnectorRequest.class), any());
+        doThrow(InvalidRequestException.class).when(client).createConnector(any(CreateConnectorRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -115,18 +100,12 @@ public class CreateHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnInvalidRequestException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnInvalidRequestException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_InternalServiceErrorExceptionFailed() {
-        CreateHandler handler = new CreateHandler(client);
-
-        doThrow(InternalServiceErrorException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(CreateConnectorRequest.class), any());
+        doThrow(InternalServiceErrorException.class).when(client).createConnector(any(CreateConnectorRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -134,18 +113,12 @@ public class CreateHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnServiceInternalErrorException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnServiceInternalErrorException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_ResourceExistsExceptionFailed() {
-        CreateHandler handler = new CreateHandler(client);
-
-        doThrow(ResourceExistsException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(CreateConnectorRequest.class), any());
+        doThrow(ResourceExistsException.class).when(client).createConnector(any(CreateConnectorRequest.class));
 
         ResourceModel model =
                 ResourceModel.builder().connectorId(TEST_CONNECTOR_ID).build();
@@ -154,18 +127,12 @@ public class CreateHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnAlreadyExistsException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnAlreadyExistsException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_ThrottlingExceptionFailed() {
-        CreateHandler handler = new CreateHandler(client);
-
-        doThrow(ThrottlingException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(CreateConnectorRequest.class), any());
+        doThrow(ThrottlingException.class).when(client).createConnector(any(CreateConnectorRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -173,18 +140,12 @@ public class CreateHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnThrottlingException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnThrottlingException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_TransferExceptionFailed() {
-        CreateHandler handler = new CreateHandler(client);
-
-        doThrow(TransferException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(CreateConnectorRequest.class), any());
+        doThrow(TransferException.class).when(client).createConnector(any(CreateConnectorRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -192,8 +153,6 @@ public class CreateHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnGeneralServiceException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnGeneralServiceException.class, () -> callHandler(request));
     }
 }

--- a/aws-transfer-connector/src/test/java/software/amazon/transfer/connector/DeleteHandlerTest.java
+++ b/aws-transfer-connector/src/test/java/software/amazon/transfer/connector/DeleteHandlerTest.java
@@ -4,16 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static software.amazon.transfer.connector.AbstractTestBase.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import software.amazon.awssdk.services.transfer.TransferClient;
 import software.amazon.awssdk.services.transfer.model.DeleteConnectorRequest;
 import software.amazon.awssdk.services.transfer.model.InternalServiceErrorException;
 import software.amazon.awssdk.services.transfer.model.InvalidRequestException;
@@ -23,35 +20,27 @@ import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 @ExtendWith(MockitoExtension.class)
-public class DeleteHandlerTest {
+public class DeleteHandlerTest extends AbstractTestBase {
 
-    @Mock
-    private AmazonWebServicesClientProxy proxy;
+    private MockableBaseHandler<CallbackContext> handler;
 
-    @Mock
-    private Logger logger;
-
-    @Mock
-    private TransferClient client;
+    @Override
+    MockableBaseHandler<CallbackContext> getHandler() {
+        return handler;
+    }
 
     @BeforeEach
-    public void setup() {
-        proxy = mock(AmazonWebServicesClientProxy.class);
-        logger = mock(Logger.class);
-        client = mock(TransferClient.class);
+    public void setupTestData() {
+        handler = new DeleteHandler();
     }
 
     @Test
     public void handleRequest_SimpleSuccess() {
-        final DeleteHandler handler = new DeleteHandler(client);
-
         final ResourceModel model =
                 ResourceModel.builder().connectorId(TEST_CONNECTOR_ID).build();
 
@@ -59,8 +48,7 @@ public class DeleteHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        final ProgressEvent<ResourceModel, CallbackContext> response =
-                handler.handleRequest(proxy, request, null, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = callHandler(request);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -73,11 +61,7 @@ public class DeleteHandlerTest {
 
     @Test
     public void handleRequest_InvalidRequestExceptionFailed() {
-        DeleteHandler handler = new DeleteHandler(client);
-
-        doThrow(InvalidRequestException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(DeleteConnectorRequest.class), any());
+        doThrow(InvalidRequestException.class).when(client).deleteConnector(any(DeleteConnectorRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -85,18 +69,12 @@ public class DeleteHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnInvalidRequestException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnInvalidRequestException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_InternalServiceErrorExceptionFailed() {
-        DeleteHandler handler = new DeleteHandler(client);
-
-        doThrow(InternalServiceErrorException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(DeleteConnectorRequest.class), any());
+        doThrow(InternalServiceErrorException.class).when(client).deleteConnector(any(DeleteConnectorRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -104,18 +82,12 @@ public class DeleteHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnServiceInternalErrorException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnServiceInternalErrorException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_ResourceNotFoundExceptionFailed() {
-        DeleteHandler handler = new DeleteHandler(client);
-
-        doThrow(ResourceNotFoundException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(DeleteConnectorRequest.class), any());
+        doThrow(ResourceNotFoundException.class).when(client).deleteConnector(any(DeleteConnectorRequest.class));
 
         ResourceModel model =
                 ResourceModel.builder().connectorId(TEST_CONNECTOR_ID).build();
@@ -124,18 +96,12 @@ public class DeleteHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnNotFoundException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnNotFoundException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_TransferExceptionFailed() {
-        DeleteHandler handler = new DeleteHandler(client);
-
-        doThrow(TransferException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(DeleteConnectorRequest.class), any());
+        doThrow(TransferException.class).when(client).deleteConnector(any(DeleteConnectorRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -143,8 +109,6 @@ public class DeleteHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnGeneralServiceException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnGeneralServiceException.class, () -> callHandler(request));
     }
 }

--- a/aws-transfer-connector/src/test/java/software/amazon/transfer/connector/UpdateHandlerTest.java
+++ b/aws-transfer-connector/src/test/java/software/amazon/transfer/connector/UpdateHandlerTest.java
@@ -12,18 +12,16 @@ import static software.amazon.transfer.connector.AbstractTestBase.*;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import software.amazon.awssdk.services.transfer.TransferClient;
 import software.amazon.awssdk.services.transfer.model.InternalServiceErrorException;
 import software.amazon.awssdk.services.transfer.model.InvalidRequestException;
 import software.amazon.awssdk.services.transfer.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.transfer.model.TagResourceRequest;
 import software.amazon.awssdk.services.transfer.model.TransferException;
-import software.amazon.awssdk.services.transfer.model.TransferRequest;
 import software.amazon.awssdk.services.transfer.model.UntagResourceRequest;
 import software.amazon.awssdk.services.transfer.model.UpdateConnectorRequest;
 import software.amazon.awssdk.services.transfer.model.UpdateConnectorResponse;
@@ -31,28 +29,27 @@ import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 @ExtendWith(MockitoExtension.class)
-public class UpdateHandlerTest {
+public class UpdateHandlerTest extends AbstractTestBase {
 
-    @Mock
-    private AmazonWebServicesClientProxy proxy;
+    private MockableBaseHandler<CallbackContext> handler;
 
-    @Mock
-    private Logger logger;
+    @Override
+    MockableBaseHandler<CallbackContext> getHandler() {
+        return handler;
+    }
 
-    @Mock
-    private TransferClient client;
+    @BeforeEach
+    public void setupTestData() {
+        handler = new UpdateHandler();
+    }
 
     @Test
     public void handleRequest_SimpleSuccess() {
-        final UpdateHandler handler = new UpdateHandler(client);
-
         final ResourceModel model = ResourceModel.builder()
                 .connectorId(TEST_CONNECTOR_ID)
                 .accessRole(TEST_ACCESS_ROLE)
@@ -65,10 +62,9 @@ public class UpdateHandlerTest {
         UpdateConnectorResponse updateConnectorResponse =
                 UpdateConnectorResponse.builder().connectorId(TEST_CONNECTOR_ID).build();
 
-        doReturn(updateConnectorResponse).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doReturn(updateConnectorResponse).when(client).updateConnector(any(UpdateConnectorRequest.class));
 
-        final ProgressEvent<ResourceModel, CallbackContext> response =
-                handler.handleRequest(proxy, request, null, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = callHandler(request);
 
         ResourceModel testModel = response.getResourceModel();
         assertThat(response).isNotNull();
@@ -80,12 +76,11 @@ public class UpdateHandlerTest {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
         assertThat(testModel).hasFieldOrPropertyWithValue("accessRole", TEST_ACCESS_ROLE);
-        verify(proxy, times(1)).injectCredentialsAndInvokeV2(any(UpdateConnectorRequest.class), any());
+        verify(client, times(1)).updateConnector(any(UpdateConnectorRequest.class));
     }
 
     @Test
     public void handleRequest_AddTagInvoked() {
-        UpdateHandler handler = new UpdateHandler(client);
         Set<Tag> desiredTags = TEST_TAG_MAP.entrySet().stream()
                 .map(tag ->
                         Tag.builder().key(tag.getKey()).value(tag.getValue()).build())
@@ -99,7 +94,7 @@ public class UpdateHandlerTest {
                 .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, null, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = callHandler(request);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -110,13 +105,12 @@ public class UpdateHandlerTest {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
         assertThat(response.getResourceModel().getTags()).isEqualTo(desiredTags);
-        verify(proxy, times(1)).injectCredentialsAndInvokeV2(any(TagResourceRequest.class), any());
-        verify(proxy, times(1)).injectCredentialsAndInvokeV2(any(UpdateConnectorRequest.class), any());
+        verify(client, times(1)).tagResource(any(TagResourceRequest.class));
+        verify(client, times(1)).updateConnector(any(UpdateConnectorRequest.class));
     }
 
     @Test
     public void handleRequest_RemoveTagInvoked() {
-        UpdateHandler handler = new UpdateHandler(client);
         Set<Tag> systemTags = SYSTEM_TAG_MAP.entrySet().stream()
                 .map(tag ->
                         Tag.builder().key(tag.getKey()).value(tag.getValue()).build())
@@ -130,7 +124,7 @@ public class UpdateHandlerTest {
                 .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, null, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = callHandler(request);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -141,15 +135,13 @@ public class UpdateHandlerTest {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
         assertThat(response.getResourceModel().getTags()).isEqualTo(systemTags);
-        verify(proxy, times(1)).injectCredentialsAndInvokeV2(any(UntagResourceRequest.class), any());
-        verify(proxy, times(1)).injectCredentialsAndInvokeV2(any(UpdateConnectorRequest.class), any());
+        verify(client, times(1)).untagResource(any(UntagResourceRequest.class));
+        verify(client, times(1)).updateConnector(any(UpdateConnectorRequest.class));
     }
 
     @Test
     public void handleRequest_InvalidRequestExceptionFailed() {
-        UpdateHandler handler = new UpdateHandler(client);
-
-        doThrow(InvalidRequestException.class).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doThrow(InvalidRequestException.class).when(client).updateConnector(any(UpdateConnectorRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -159,18 +151,12 @@ public class UpdateHandlerTest {
                 .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        assertThrows(CfnInvalidRequestException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnInvalidRequestException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_InternalServiceErrorExceptionFailed() {
-        UpdateHandler handler = new UpdateHandler(client);
-
-        doThrow(InternalServiceErrorException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(TransferRequest.class), any());
+        doThrow(InternalServiceErrorException.class).when(client).updateConnector(any(UpdateConnectorRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -180,18 +166,12 @@ public class UpdateHandlerTest {
                 .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        assertThrows(CfnServiceInternalErrorException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnServiceInternalErrorException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_ResourceNotFoundExceptionFailed() {
-        UpdateHandler handler = new UpdateHandler(client);
-
-        doThrow(ResourceNotFoundException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(TransferRequest.class), any());
+        doThrow(ResourceNotFoundException.class).when(client).updateConnector(any(UpdateConnectorRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -201,16 +181,12 @@ public class UpdateHandlerTest {
                 .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        assertThrows(CfnNotFoundException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnNotFoundException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_TransferExceptionFailed() {
-        UpdateHandler handler = new UpdateHandler(client);
-
-        doThrow(TransferException.class).when(proxy).injectCredentialsAndInvokeV2(any(TransferRequest.class), any());
+        doThrow(TransferException.class).when(client).updateConnector(any(UpdateConnectorRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -220,8 +196,6 @@ public class UpdateHandlerTest {
                 .systemTags(SYSTEM_TAG_MAP)
                 .build();
 
-        assertThrows(CfnGeneralServiceException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnGeneralServiceException.class, () -> callHandler(request));
     }
 }

--- a/aws-transfer-profile/spotbugs-exclude.xml
+++ b/aws-transfer-profile/spotbugs-exclude.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <Match>
+        <Class name="software.amazon.transfer.profile.HandlerWrapperExecutable"/>
+    </Match>
+    <Match>
+        <Class name="software.amazon.transfer.profile.HandlerWrapper"/>
+    </Match>
+    <Match>
+        <Class name="software.amazon.transfer.profile.ResourceModel"/>
+    </Match>
+    <Match>
+        <Bug code="RCN,EI,EI2"/>
+    </Match>
+</FindBugsFilter>

--- a/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/BaseHandlerStd.java
+++ b/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/BaseHandlerStd.java
@@ -1,0 +1,40 @@
+package software.amazon.transfer.profile;
+
+import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+/**
+ * The purpose of this base class is to allow a simple calling pattern that
+ * makes testing Uluru handlers easier and avoids having to store context
+ * in class fields. The {@link MockableBaseHandler} interface is used to
+ * make isolation of the inner call such that in testing we guarantee that
+ * the caller will not pick the wrong method and avoid human error.
+ */
+public abstract class BaseHandlerStd extends BaseHandler<CallbackContext>
+        implements MockableBaseHandler<CallbackContext> {
+    @Override
+    public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final Logger logger) {
+        return handleRequest(
+                proxy,
+                request,
+                callbackContext != null ? callbackContext : new CallbackContext(),
+                proxy.newProxy(ClientBuilder::getClient),
+                logger);
+    }
+
+    @Override
+    public abstract ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
+            final Logger logger);
+}

--- a/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/CreateHandler.java
+++ b/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/CreateHandler.java
@@ -19,6 +19,7 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.amazonaws.util.CollectionUtils;
@@ -26,23 +27,14 @@ import com.amazonaws.util.CollectionUtils;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class CreateHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public CreateHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class CreateHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         final ResourceModel model = request.getDesiredResourceState();
 
@@ -67,7 +59,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                 .profileType(model.getProfileType())
                 .build();
 
-        try {
+        try (TransferClient client = proxyClient.client()) {
             CreateProfileResponse response =
                     proxy.injectCredentialsAndInvokeV2(createProfileRequest, client::createProfile);
             model.setProfileId(response.profileId());

--- a/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/DeleteHandler.java
+++ b/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/DeleteHandler.java
@@ -14,34 +14,26 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class DeleteHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public DeleteHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class DeleteHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         final ResourceModel model = request.getDesiredResourceState();
         DeleteProfileRequest deleteProfileRequest =
                 DeleteProfileRequest.builder().profileId(model.getProfileId()).build();
 
-        try {
+        try (TransferClient client = proxyClient.client()) {
             proxy.injectCredentialsAndInvokeV2(deleteProfileRequest, client::deleteProfile);
             logger.log(
                     String.format("%s %s deleted successfully", ResourceModel.TYPE_NAME, model.getPrimaryIdentifier()));

--- a/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/ListHandler.java
+++ b/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/ListHandler.java
@@ -18,29 +18,20 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class ListHandler extends BaseHandler<CallbackContext> {
-
-    private TransferClient client;
-
-    public ListHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class ListHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         final List<ResourceModel> models = new ArrayList<>();
         ListProfilesRequest listProfilesRequest = ListProfilesRequest.builder()
@@ -49,7 +40,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
                 .profileType(request.getDesiredResourceState().getProfileType())
                 .build();
 
-        try {
+        try (TransferClient client = proxyClient.client()) {
             ListProfilesResponse response =
                     proxy.injectCredentialsAndInvokeV2(listProfilesRequest, client::listProfiles);
 

--- a/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/MockableBaseHandler.java
+++ b/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/MockableBaseHandler.java
@@ -1,0 +1,24 @@
+package software.amazon.transfer.profile;
+
+import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+/**
+ * Interface exposing the only handler method that should be used when
+ * testing Uluru handlers. This provides a mechanism to feed the call chain
+ * a mock client as needed without complex static mocking of the ClientBuilder.
+ *
+ * @param <CallbackT>
+ */
+interface MockableBaseHandler<CallbackT> {
+    ProgressEvent<ResourceModel, CallbackT> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackT callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
+            final Logger logger);
+}

--- a/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/ReadHandler.java
+++ b/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/ReadHandler.java
@@ -18,6 +18,7 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.amazonaws.util.CollectionUtils;
@@ -25,29 +26,20 @@ import com.amazonaws.util.CollectionUtils;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class ReadHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public ReadHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class ReadHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         final ResourceModel model = request.getDesiredResourceState();
         DescribeProfileRequest describeProfileRequest =
                 DescribeProfileRequest.builder().profileId(model.getProfileId()).build();
 
-        try {
+        try (TransferClient client = proxyClient.client()) {
             DescribeProfileResponse describeProfileResponse =
                     proxy.injectCredentialsAndInvokeV2(describeProfileRequest, client::describeProfile);
             logger.log(String.format(

--- a/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/UpdateHandler.java
+++ b/aws-transfer-profile/src/main/java/software/amazon/transfer/profile/UpdateHandler.java
@@ -24,28 +24,20 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class UpdateHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public UpdateHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class UpdateHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         final ResourceModel model = request.getDesiredResourceState();
         UpdateProfileRequest updateProfileRequest = UpdateProfileRequest.builder()
@@ -72,7 +64,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         Set<Tag> tagsToAdd = Sets.difference(new HashSet<>(desiredTags), new HashSet<>(previousTags));
         Set<Tag> tagsToRemove = Sets.difference(new HashSet<>(previousTags), new HashSet<>(desiredTags));
 
-        try {
+        try (TransferClient client = proxyClient.client()) {
             proxy.injectCredentialsAndInvokeV2(updateProfileRequest, client::updateProfile);
             logger.log(String.format("%s updated successfully", ResourceModel.TYPE_NAME));
 

--- a/aws-transfer-profile/src/test/java/software/amazon/transfer/profile/AbstractTestBase.java
+++ b/aws-transfer-profile/src/test/java/software/amazon/transfer/profile/AbstractTestBase.java
@@ -1,29 +1,125 @@
 package software.amazon.transfer.profile;
 
+import static org.mockito.Mockito.mock;
+
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-public class AbstractTestBase {
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
 
-    public static Map<String, String> RESOURCE_TAG_MAP = Collections.singletonMap("key", "value");
-    public static Map<String, String> SYSTEM_TAG_MAP =
+import software.amazon.awssdk.awscore.AwsRequest;
+import software.amazon.awssdk.awscore.AwsResponse;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Credentials;
+import software.amazon.cloudformation.proxy.LoggerProxy;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+public abstract class AbstractTestBase {
+
+    public static final Map<String, String> RESOURCE_TAG_MAP = Collections.singletonMap("key", "value");
+    public static final Map<String, String> SYSTEM_TAG_MAP =
             Collections.singletonMap("aws:cloudformation:stack-name", "StackName");
-    public static Map<String, String> TEST_TAG_MAP =
+    public static final Map<String, String> TEST_TAG_MAP =
             ImmutableMap.of("key", "value", "aws:cloudformation:stack-name", "StackName");
-    public static Set<Tag> MODEL_TAGS =
+    public static final Set<Tag> MODEL_TAGS =
             ImmutableSet.of(Tag.builder().key("key").value("value").build());
-    public static software.amazon.awssdk.services.transfer.model.Tag SDK_MODEL_TAG =
+    public static final software.amazon.awssdk.services.transfer.model.Tag SDK_MODEL_TAG =
             software.amazon.awssdk.services.transfer.model.Tag.builder()
                     .key("key")
                     .value("value")
                     .build();
-    public static software.amazon.awssdk.services.transfer.model.Tag SDK_SYSTEM_TAG =
+    public static final software.amazon.awssdk.services.transfer.model.Tag SDK_SYSTEM_TAG =
             software.amazon.awssdk.services.transfer.model.Tag.builder()
                     .key("aws:cloudformation:stack-name")
                     .value("StackName")
                     .build();
+
+    abstract MockableBaseHandler<CallbackContext> getHandler();
+
+    protected ProgressEvent<ResourceModel, CallbackContext> callHandler(ResourceHandlerRequest<ResourceModel> request) {
+        return getHandler().handleRequest(proxy, request, null, proxyClient, logger);
+    }
+
+    protected static final Credentials MOCK_CREDENTIALS;
+    protected static final LoggerProxy logger;
+
+    static {
+        MOCK_CREDENTIALS = new Credentials("accessKey", "secretKey", "token");
+        logger = new LoggerProxy();
+    }
+
+    protected AmazonWebServicesClientProxy proxy;
+
+    protected ProxyClient<TransferClient> proxyClient;
+
+    @Mock
+    protected TransferClient client;
+
+    @BeforeEach
+    public void setup() {
+        proxy = new AmazonWebServicesClientProxy(
+                logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
+        client = mock(TransferClient.class);
+        proxyClient = MOCK_PROXY(proxy, client);
+    }
+
+    static <T> ProxyClient<T> MOCK_PROXY(final AmazonWebServicesClientProxy proxy, final T sdkClient) {
+        return new ProxyClient<T>() {
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseT injectCredentialsAndInvokeV2(
+                    RequestT request, Function<RequestT, ResponseT> requestFunction) {
+                return proxy.injectCredentialsAndInvokeV2(request, requestFunction);
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+                    CompletableFuture<ResponseT> injectCredentialsAndInvokeV2Async(
+                            RequestT request, Function<RequestT, CompletableFuture<ResponseT>> requestFunction) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <
+                            RequestT extends AwsRequest,
+                            ResponseT extends AwsResponse,
+                            IterableT extends SdkIterable<ResponseT>>
+                    IterableT injectCredentialsAndInvokeIterableV2(
+                            RequestT request, Function<RequestT, IterableT> requestFunction) {
+                return proxy.injectCredentialsAndInvokeIterableV2(request, requestFunction);
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+                    ResponseInputStream<ResponseT> injectCredentialsAndInvokeV2InputStream(
+                            RequestT requestT, Function<RequestT, ResponseInputStream<ResponseT>> function) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+                    ResponseBytes<ResponseT> injectCredentialsAndInvokeV2Bytes(
+                            RequestT requestT, Function<RequestT, ResponseBytes<ResponseT>> function) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public T client() {
+                return sdkClient;
+            }
+        };
+    }
 }

--- a/aws-transfer-profile/src/test/java/software/amazon/transfer/profile/BaseHandlerStdTest.java
+++ b/aws-transfer-profile/src/test/java/software/amazon/transfer/profile/BaseHandlerStdTest.java
@@ -1,0 +1,56 @@
+package software.amazon.transfer.profile;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+@ExtendWith(MockitoExtension.class)
+public class BaseHandlerStdTest {
+    @Mock
+    private AmazonWebServicesClientProxy proxy;
+
+    static class MockTestHandler extends BaseHandlerStd {
+        @Override
+        public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+                AmazonWebServicesClientProxy proxy,
+                ResourceHandlerRequest<ResourceModel> request,
+                CallbackContext callbackContext,
+                ProxyClient<TransferClient> proxyClient,
+                Logger logger) {
+            assertNotNull(callbackContext);
+            return null;
+        }
+    }
+
+    @Test
+    void justToCover3LinesOfCode() {
+        var uut = new MockTestHandler();
+
+        // Check with null CallbackContext
+        uut.handleRequest(proxy, null, null, null);
+        verify(proxy, times(1)).newProxy(any());
+        verifyNoMoreInteractions(proxy);
+        reset(proxy);
+
+        // Check with non-null CallbackContext
+        uut.handleRequest(proxy, null, new CallbackContext(), null);
+        verify(proxy, times(1)).newProxy(any());
+        verifyNoMoreInteractions(proxy);
+        reset(proxy);
+    }
+}

--- a/aws-transfer-profile/src/test/java/software/amazon/transfer/profile/DeleteHandlerTest.java
+++ b/aws-transfer-profile/src/test/java/software/amazon/transfer/profile/DeleteHandlerTest.java
@@ -5,12 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import software.amazon.awssdk.services.transfer.TransferClient;
 import software.amazon.awssdk.services.transfer.model.DeleteProfileRequest;
 import software.amazon.awssdk.services.transfer.model.InternalServiceErrorException;
 import software.amazon.awssdk.services.transfer.model.InvalidRequestException;
@@ -20,36 +19,34 @@ import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 @ExtendWith(MockitoExtension.class)
-public class DeleteHandlerTest {
+public class DeleteHandlerTest extends AbstractTestBase {
 
-    @Mock
-    private AmazonWebServicesClientProxy proxy;
+    private MockableBaseHandler<CallbackContext> handler;
 
-    @Mock
-    private Logger logger;
+    @Override
+    MockableBaseHandler<CallbackContext> getHandler() {
+        return handler;
+    }
 
-    @Mock
-    private TransferClient client;
+    @BeforeEach
+    public void setupTestData() {
+        handler = new DeleteHandler();
+    }
 
     @Test
     public void handleRequest_SimpleSuccess() {
-        final DeleteHandler handler = new DeleteHandler(client);
-
         final ResourceModel model = ResourceModel.builder().profileId("testid").build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(model)
                 .build();
 
-        final ProgressEvent<ResourceModel, CallbackContext> response =
-                handler.handleRequest(proxy, request, null, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = callHandler(request);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -62,11 +59,7 @@ public class DeleteHandlerTest {
 
     @Test
     public void handleRequest_InvalidRequestExceptionFailed() {
-        DeleteHandler handler = new DeleteHandler(client);
-
-        doThrow(InvalidRequestException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(DeleteProfileRequest.class), any());
+        doThrow(InvalidRequestException.class).when(client).deleteProfile(any(DeleteProfileRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -74,18 +67,12 @@ public class DeleteHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnInvalidRequestException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnInvalidRequestException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_InternalServiceErrorExceptionFailed() {
-        DeleteHandler handler = new DeleteHandler(client);
-
-        doThrow(InternalServiceErrorException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(DeleteProfileRequest.class), any());
+        doThrow(InternalServiceErrorException.class).when(client).deleteProfile(any(DeleteProfileRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -93,18 +80,12 @@ public class DeleteHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnServiceInternalErrorException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnServiceInternalErrorException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_ResourceNotFoundExceptionFailed() {
-        DeleteHandler handler = new DeleteHandler(client);
-
-        doThrow(ResourceNotFoundException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(DeleteProfileRequest.class), any());
+        doThrow(ResourceNotFoundException.class).when(client).deleteProfile(any(DeleteProfileRequest.class));
 
         ResourceModel model = ResourceModel.builder().profileId("testId").build();
 
@@ -112,18 +93,12 @@ public class DeleteHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnNotFoundException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnNotFoundException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_TransferExceptionFailed() {
-        DeleteHandler handler = new DeleteHandler(client);
-
-        doThrow(TransferException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(DeleteProfileRequest.class), any());
+        doThrow(TransferException.class).when(client).deleteProfile(any(DeleteProfileRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -131,8 +106,6 @@ public class DeleteHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnGeneralServiceException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnGeneralServiceException.class, () -> callHandler(request));
     }
 }

--- a/aws-transfer-profile/src/test/java/software/amazon/transfer/profile/ListHandlerTest.java
+++ b/aws-transfer-profile/src/test/java/software/amazon/transfer/profile/ListHandlerTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import software.amazon.awssdk.services.transfer.TransferClient;
 import software.amazon.awssdk.services.transfer.model.InternalServiceErrorException;
 import software.amazon.awssdk.services.transfer.model.InvalidRequestException;
 import software.amazon.awssdk.services.transfer.model.ListProfilesRequest;
@@ -24,30 +23,27 @@ import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
 import software.amazon.cloudformation.exceptions.ResourceNotFoundException;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 @ExtendWith(MockitoExtension.class)
-public class ListHandlerTest {
+public class ListHandlerTest extends AbstractTestBase {
 
-    private AmazonWebServicesClientProxy proxy;
-    private Logger logger;
-    private TransferClient client;
+    private MockableBaseHandler<CallbackContext> handler;
+
+    @Override
+    MockableBaseHandler<CallbackContext> getHandler() {
+        return handler;
+    }
 
     @BeforeEach
-    public void setup() {
-        proxy = mock(AmazonWebServicesClientProxy.class);
-        logger = mock(Logger.class);
-        client = mock(TransferClient.class);
+    public void setupTestData() {
+        handler = new ListHandler();
     }
 
     @Test
     public void handleRequest_SimpleSuccess() {
-        final ListHandler handler = new ListHandler(client);
-
         ListedProfile listedProfile = ListedProfile.builder()
                 .profileId("testid")
                 .arn("testarn")
@@ -64,10 +60,9 @@ public class ListHandlerTest {
         ListProfilesResponse listProfilesResponse =
                 ListProfilesResponse.builder().profiles(listedProfile).build();
 
-        doReturn(listProfilesResponse).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doReturn(listProfilesResponse).when(client).listProfiles(any(ListProfilesRequest.class));
 
-        final ProgressEvent<ResourceModel, CallbackContext> response =
-                handler.handleRequest(proxy, request, null, logger);
+        final ProgressEvent<ResourceModel, CallbackContext> response = callHandler(request);
 
         List<ResourceModel> testModels = response.getResourceModels();
 
@@ -91,11 +86,7 @@ public class ListHandlerTest {
 
     @Test
     public void handleRequest_InvalidRequestExceptionFailed() {
-        ListHandler handler = new ListHandler(client);
-
-        doThrow(InvalidRequestException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(ListProfilesRequest.class), any());
+        doThrow(InvalidRequestException.class).when(client).listProfiles(any(ListProfilesRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -103,18 +94,12 @@ public class ListHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnInvalidRequestException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnInvalidRequestException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_InternalServiceErrorExceptionFailed() {
-        ListHandler handler = new ListHandler(client);
-
-        doThrow(InternalServiceErrorException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(ListProfilesRequest.class), any());
+        doThrow(InternalServiceErrorException.class).when(client).listProfiles(any(ListProfilesRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -122,18 +107,12 @@ public class ListHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnServiceInternalErrorException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnServiceInternalErrorException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_TransferExceptionFailed() {
-        ListHandler handler = new ListHandler(client);
-
-        doThrow(TransferException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(ListProfilesRequest.class), any());
+        doThrow(TransferException.class).when(client).listProfiles(any(ListProfilesRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -141,18 +120,12 @@ public class ListHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnGeneralServiceException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnGeneralServiceException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_ResourceNotFoundExceptionFailed() {
-        ListHandler handler = new ListHandler(client);
-
-        doThrow(ResourceNotFoundException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(ListProfilesRequest.class), any());
+        doThrow(ResourceNotFoundException.class).when(client).listProfiles(any(ListProfilesRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -160,8 +133,6 @@ public class ListHandlerTest {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnNotFoundException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnNotFoundException.class, () -> callHandler(request));
     }
 }

--- a/aws-transfer-server/spotbugs-exclude.xml
+++ b/aws-transfer-server/spotbugs-exclude.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <Match>
+        <Class name="software.amazon.transfer.server.HandlerWrapperExecutable"/>
+    </Match>
+    <Match>
+        <Class name="software.amazon.transfer.server.HandlerWrapper"/>
+    </Match>
+    <Match>
+        <Class name="software.amazon.transfer.server.ResourceModel"/>
+    </Match>
+    <Match>
+        <Bug code="RCN,EI,EI2"/>
+    </Match>
+</FindBugsFilter>

--- a/aws-transfer-user/docs/README.md
+++ b/aws-transfer-user/docs/README.md
@@ -126,6 +126,8 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 #### SshPublicKeys
 
+This represents the SSH User Public Keys for CloudFormation resource
+
 _Required_: No
 
 _Type_: List of String

--- a/aws-transfer-user/spotbugs-exclude.xml
+++ b/aws-transfer-user/spotbugs-exclude.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <Match>
+        <Class name="software.amazon.transfer.user.HandlerWrapperExecutable"/>
+    </Match>
+    <Match>
+        <Class name="software.amazon.transfer.user.HandlerWrapper"/>
+    </Match>
+    <Match>
+        <Class name="software.amazon.transfer.user.ResourceModel"/>
+    </Match>
+    <Match>
+        <Bug code="RCN,EI,EI2"/>
+    </Match>
+</FindBugsFilter>

--- a/aws-transfer-workflow/spotbugs-exclude.xml
+++ b/aws-transfer-workflow/spotbugs-exclude.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <Match>
+        <Class name="software.amazon.transfer.workflow.HandlerWrapperExecutable"/>
+    </Match>
+    <Match>
+        <Class name="software.amazon.transfer.workflow.HandlerWrapper"/>
+    </Match>
+    <Match>
+        <Class name="software.amazon.transfer.workflow.ResourceModel"/>
+    </Match>
+    <Match>
+        <Bug code="RCN,EI,EI2"/>
+    </Match>
+</FindBugsFilter>

--- a/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/BaseHandlerStd.java
+++ b/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/BaseHandlerStd.java
@@ -1,0 +1,40 @@
+package software.amazon.transfer.workflow;
+
+import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+/**
+ * The purpose of this base class is to allow a simple calling pattern that
+ * makes testing Uluru handlers easier and avoids having to store context
+ * in class fields. The {@link MockableBaseHandler} interface is used to
+ * make isolation of the inner call such that in testing we guarantee that
+ * the caller will not pick the wrong method and avoid human error.
+ */
+public abstract class BaseHandlerStd extends BaseHandler<CallbackContext>
+        implements MockableBaseHandler<CallbackContext> {
+    @Override
+    public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final Logger logger) {
+        return handleRequest(
+                proxy,
+                request,
+                callbackContext != null ? callbackContext : new CallbackContext(),
+                proxy.newProxy(ClientBuilder::getClient),
+                logger);
+    }
+
+    @Override
+    public abstract ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
+            final Logger logger);
+}

--- a/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/CreateHandler.java
+++ b/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/CreateHandler.java
@@ -21,6 +21,7 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.amazonaws.util.CollectionUtils;
@@ -28,23 +29,14 @@ import com.amazonaws.util.CollectionUtils;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class CreateHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public CreateHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class CreateHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         ResourceModel model = request.getDesiredResourceState();
 
@@ -79,7 +71,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                                         .map(Converter.TagConverter::toSdk)
                                         .collect(Collectors.toList()))
                 .build();
-        try {
+        try (TransferClient client = proxyClient.client()) {
             CreateWorkflowResponse response =
                     proxy.injectCredentialsAndInvokeV2(createWorkflowRequest, client::createWorkflow);
             model.setWorkflowId(response.workflowId());

--- a/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/DeleteHandler.java
+++ b/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/DeleteHandler.java
@@ -14,35 +14,27 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class DeleteHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public DeleteHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class DeleteHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         final ResourceModel model = request.getDesiredResourceState();
 
         final DeleteWorkflowRequest deleteWorkflowRequest = DeleteWorkflowRequest.builder()
                 .workflowId(model.getWorkflowId())
                 .build();
-        try {
+        try (TransferClient client = proxyClient.client()) {
             proxy.injectCredentialsAndInvokeV2(deleteWorkflowRequest, client::deleteWorkflow);
             logger.log(
                     String.format("%s %s deleted successfully", ResourceModel.TYPE_NAME, model.getPrimaryIdentifier()));

--- a/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/ListHandler.java
+++ b/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/ListHandler.java
@@ -16,28 +16,20 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class ListHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public ListHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class ListHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         final List<ResourceModel> models = new ArrayList<>();
 
@@ -46,7 +38,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
                 .nextToken(request.getNextToken())
                 .build();
 
-        try {
+        try (TransferClient client = proxyClient.client()) {
             ListWorkflowsResponse response =
                     proxy.injectCredentialsAndInvokeV2(listWorkflowsRequest, client::listWorkflows);
 

--- a/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/MockableBaseHandler.java
+++ b/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/MockableBaseHandler.java
@@ -1,0 +1,24 @@
+package software.amazon.transfer.workflow;
+
+import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+/**
+ * Interface exposing the only handler method that should be used when
+ * testing Uluru handlers. This provides a mechanism to feed the call chain
+ * a mock client as needed without complex static mocking of the ClientBuilder.
+ *
+ * @param <CallbackT>
+ */
+interface MockableBaseHandler<CallbackT> {
+    ProgressEvent<ResourceModel, CallbackT> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackT callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
+            final Logger logger);
+}

--- a/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/ReadHandler.java
+++ b/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/ReadHandler.java
@@ -18,6 +18,7 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import com.amazonaws.util.CollectionUtils;
@@ -25,29 +26,20 @@ import com.amazonaws.util.CollectionUtils;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class ReadHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public ReadHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class ReadHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,
             final ResourceHandlerRequest<ResourceModel> request,
             final CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             final Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         ResourceModel model = request.getDesiredResourceState();
         DescribeWorkflowRequest describeWorkflowRequest = DescribeWorkflowRequest.builder()
                 .workflowId(model.getWorkflowId())
                 .build();
-        try {
+        try (TransferClient client = proxyClient.client()) {
             DescribeWorkflowResponse response =
                     proxy.injectCredentialsAndInvokeV2(describeWorkflowRequest, client::describeWorkflow);
             logger.log(String.format(

--- a/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/UpdateHandler.java
+++ b/aws-transfer-workflow/src/main/java/software/amazon/transfer/workflow/UpdateHandler.java
@@ -23,28 +23,20 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-public class UpdateHandler extends BaseHandler<CallbackContext> {
-    private TransferClient client;
-
-    public UpdateHandler(TransferClient client) {
-        this.client = client;
-    }
-
+public class UpdateHandler extends BaseHandlerStd {
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             AmazonWebServicesClientProxy proxy,
             ResourceHandlerRequest<ResourceModel> request,
             CallbackContext callbackContext,
+            final ProxyClient<TransferClient> proxyClient,
             Logger logger) {
-
-        if (this.client == null) {
-            this.client = ClientBuilder.getClient();
-        }
 
         ResourceModel model = request.getDesiredResourceState();
         String arn = String.format(
@@ -67,7 +59,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         Set<Tag> tagsToAdd = Sets.difference(new HashSet<>(desiredTags), new HashSet<>(previousTags));
         Set<Tag> tagsToRemove = Sets.difference(new HashSet<>(previousTags), new HashSet<>(desiredTags));
 
-        try {
+        try (TransferClient client = proxyClient.client()) {
             if (!tagsToAdd.isEmpty()) {
                 TagResourceRequest tagResourceRequest = TagResourceRequest.builder()
                         .arn(arn)

--- a/aws-transfer-workflow/src/test/java/software/amazon/transfer/workflow/AbstractTestBase.java
+++ b/aws-transfer-workflow/src/test/java/software/amazon/transfer/workflow/AbstractTestBase.java
@@ -1,30 +1,51 @@
 package software.amazon.transfer.workflow;
 
+import static org.mockito.Mockito.mock;
+
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+
+import software.amazon.awssdk.awscore.AwsRequest;
+import software.amazon.awssdk.awscore.AwsResponse;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.awssdk.services.transfer.TransferClient;
 import software.amazon.awssdk.services.transfer.model.OverwriteExisting;
 import software.amazon.awssdk.services.transfer.model.WorkflowStepType;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Credentials;
+import software.amazon.cloudformation.proxy.LoggerProxy;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-public class AbstractTestBase {
-    static String TEST_DESCRIPTION = "unit test";
-    static Map<String, String> RESOURCE_TAG_MAP = Collections.singletonMap("key", "value");
-    static Map<String, String> SYSTEM_TAG_MAP = Collections.singletonMap("aws:cloudformation:stack-name", "StackName");
-    static Map<String, String> TEST_TAG_MAP =
+public abstract class AbstractTestBase {
+    public static final String TEST_DESCRIPTION = "unit test";
+    public static final Map<String, String> RESOURCE_TAG_MAP = Collections.singletonMap("key", "value");
+    public static final Map<String, String> SYSTEM_TAG_MAP =
+            Collections.singletonMap("aws:cloudformation:stack-name", "StackName");
+    public static final Map<String, String> TEST_TAG_MAP =
             ImmutableMap.of("key", "value", "aws:cloudformation:stack-name", "StackName");
-    static Set<Tag> MODEL_TAGS =
+    public static final Set<Tag> MODEL_TAGS =
             ImmutableSet.of(Tag.builder().key("key").value("value").build());
-    static software.amazon.awssdk.services.transfer.model.Tag SDK_MODEL_TAG =
+    public static final software.amazon.awssdk.services.transfer.model.Tag SDK_MODEL_TAG =
             software.amazon.awssdk.services.transfer.model.Tag.builder()
                     .key("key")
                     .value("value")
                     .build();
-    static software.amazon.awssdk.services.transfer.model.Tag SDK_SYSTEM_TAG =
+    public static final software.amazon.awssdk.services.transfer.model.Tag SDK_SYSTEM_TAG =
             software.amazon.awssdk.services.transfer.model.Tag.builder()
                     .key("aws:cloudformation:stack-name")
                     .value("StackName")
@@ -63,5 +84,80 @@ public class AbstractTestBase {
                         .build())
                 .build();
         return Collections.singletonList(step);
+    }
+
+    abstract MockableBaseHandler<CallbackContext> getHandler();
+
+    protected ProgressEvent<ResourceModel, CallbackContext> callHandler(ResourceHandlerRequest<ResourceModel> request) {
+        return getHandler().handleRequest(proxy, request, null, proxyClient, logger);
+    }
+
+    protected static final Credentials MOCK_CREDENTIALS;
+    protected static final LoggerProxy logger;
+
+    static {
+        MOCK_CREDENTIALS = new Credentials("accessKey", "secretKey", "token");
+        logger = new LoggerProxy();
+    }
+
+    protected AmazonWebServicesClientProxy proxy;
+
+    protected ProxyClient<TransferClient> proxyClient;
+
+    @Mock
+    protected TransferClient client;
+
+    @BeforeEach
+    public void setup() {
+        proxy = new AmazonWebServicesClientProxy(
+                logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
+        client = mock(TransferClient.class);
+        proxyClient = MOCK_PROXY(proxy, client);
+    }
+
+    static <T> ProxyClient<T> MOCK_PROXY(final AmazonWebServicesClientProxy proxy, final T sdkClient) {
+        return new ProxyClient<T>() {
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseT injectCredentialsAndInvokeV2(
+                    RequestT request, Function<RequestT, ResponseT> requestFunction) {
+                return proxy.injectCredentialsAndInvokeV2(request, requestFunction);
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+                    CompletableFuture<ResponseT> injectCredentialsAndInvokeV2Async(
+                            RequestT request, Function<RequestT, CompletableFuture<ResponseT>> requestFunction) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <
+                            RequestT extends AwsRequest,
+                            ResponseT extends AwsResponse,
+                            IterableT extends SdkIterable<ResponseT>>
+                    IterableT injectCredentialsAndInvokeIterableV2(
+                            RequestT request, Function<RequestT, IterableT> requestFunction) {
+                return proxy.injectCredentialsAndInvokeIterableV2(request, requestFunction);
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+                    ResponseInputStream<ResponseT> injectCredentialsAndInvokeV2InputStream(
+                            RequestT requestT, Function<RequestT, ResponseInputStream<ResponseT>> function) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+                    ResponseBytes<ResponseT> injectCredentialsAndInvokeV2Bytes(
+                            RequestT requestT, Function<RequestT, ResponseBytes<ResponseT>> function) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public T client() {
+                return sdkClient;
+            }
+        };
     }
 }

--- a/aws-transfer-workflow/src/test/java/software/amazon/transfer/workflow/BaseHandlerStdTest.java
+++ b/aws-transfer-workflow/src/test/java/software/amazon/transfer/workflow/BaseHandlerStdTest.java
@@ -1,0 +1,56 @@
+package software.amazon.transfer.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import software.amazon.awssdk.services.transfer.TransferClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+@ExtendWith(MockitoExtension.class)
+public class BaseHandlerStdTest {
+    @Mock
+    private AmazonWebServicesClientProxy proxy;
+
+    static class MockTestHandler extends BaseHandlerStd {
+        @Override
+        public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+                AmazonWebServicesClientProxy proxy,
+                ResourceHandlerRequest<ResourceModel> request,
+                CallbackContext callbackContext,
+                ProxyClient<TransferClient> proxyClient,
+                Logger logger) {
+            assertNotNull(callbackContext);
+            return null;
+        }
+    }
+
+    @Test
+    void justToCover3LinesOfCode() {
+        var uut = new MockTestHandler();
+
+        // Check with null CallbackContext
+        uut.handleRequest(proxy, null, null, null);
+        verify(proxy, times(1)).newProxy(any());
+        verifyNoMoreInteractions(proxy);
+        reset(proxy);
+
+        // Check with non-null CallbackContext
+        uut.handleRequest(proxy, null, new CallbackContext(), null);
+        verify(proxy, times(1)).newProxy(any());
+        verifyNoMoreInteractions(proxy);
+        reset(proxy);
+    }
+}

--- a/aws-transfer-workflow/src/test/java/software/amazon/transfer/workflow/ReadHandlerTest.java
+++ b/aws-transfer-workflow/src/test/java/software/amazon/transfer/workflow/ReadHandlerTest.java
@@ -5,14 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import software.amazon.awssdk.services.transfer.TransferClient;
 import software.amazon.awssdk.services.transfer.model.DescribeWorkflowRequest;
 import software.amazon.awssdk.services.transfer.model.DescribeWorkflowResponse;
 import software.amazon.awssdk.services.transfer.model.DescribedWorkflow;
@@ -24,28 +22,27 @@ import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest extends AbstractTestBase {
-    private AmazonWebServicesClientProxy proxy;
-    private Logger logger;
-    private TransferClient client;
+
+    private MockableBaseHandler<CallbackContext> handler;
+
+    @Override
+    MockableBaseHandler<CallbackContext> getHandler() {
+        return handler;
+    }
 
     @BeforeEach
-    public void setup() {
-        proxy = mock(AmazonWebServicesClientProxy.class);
-        logger = mock(Logger.class);
-        client = mock(TransferClient.class);
+    public void setupTestData() {
+        handler = new ReadHandler();
     }
 
     @Test
     public void handleRequest_SimpleSuccess() {
-        ReadHandler handler = new ReadHandler(client);
         ResourceModel model = ResourceModel.builder().workflowId("testId").build();
         ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(model)
@@ -56,9 +53,9 @@ public class ReadHandlerTest extends AbstractTestBase {
                         .build())
                 .build();
 
-        doReturn(describeWorkflowResponse).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+        doReturn(describeWorkflowResponse).when(client).describeWorkflow(any(DescribeWorkflowRequest.class));
 
-        ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, null, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = callHandler(request);
         ResourceModel testModel = response.getResourceModel();
 
         assertThat(response).isNotNull();
@@ -73,11 +70,7 @@ public class ReadHandlerTest extends AbstractTestBase {
 
     @Test
     public void handleRequest_InvalidRequestExceptionFailed() {
-        ReadHandler handler = new ReadHandler(client);
-
-        doThrow(InvalidRequestException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(DescribeWorkflowRequest.class), any());
+        doThrow(InvalidRequestException.class).when(client).describeWorkflow(any(DescribeWorkflowRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -85,18 +78,12 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnInvalidRequestException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnInvalidRequestException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_InternalServiceErrorExceptionFailed() {
-        ReadHandler handler = new ReadHandler(client);
-
-        doThrow(InternalServiceErrorException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(DescribeWorkflowRequest.class), any());
+        doThrow(InternalServiceErrorException.class).when(client).describeWorkflow(any(DescribeWorkflowRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -104,18 +91,12 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnServiceInternalErrorException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnServiceInternalErrorException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_ResourceNotFoundExceptionFailed() {
-        ReadHandler handler = new ReadHandler(client);
-
-        doThrow(ResourceNotFoundException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(DescribeWorkflowRequest.class), any());
+        doThrow(ResourceNotFoundException.class).when(client).describeWorkflow(any(DescribeWorkflowRequest.class));
 
         ResourceModel model = ResourceModel.builder().workflowId("testId").build();
 
@@ -123,18 +104,12 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnNotFoundException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnNotFoundException.class, () -> callHandler(request));
     }
 
     @Test
     public void handleRequest_TransferExceptionFailed() {
-        ReadHandler handler = new ReadHandler(client);
-
-        doThrow(TransferException.class)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(any(DescribeWorkflowRequest.class), any());
+        doThrow(TransferException.class).when(client).describeWorkflow(any(DescribeWorkflowRequest.class));
 
         ResourceModel model = ResourceModel.builder().build();
 
@@ -142,8 +117,6 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .desiredResourceState(model)
                 .build();
 
-        assertThrows(CfnGeneralServiceException.class, () -> {
-            handler.handleRequest(proxy, request, null, logger);
-        });
+        assertThrows(CfnGeneralServiceException.class, () -> callHandler(request));
     }
 }


### PR DESCRIPTION
* Fix Spotbugs issues with AWS::Transfer::Agreement
* Fix Spotbugs issues with AWS::Transfer::Certificate
* Fix Spotbugs issues with AWS::Transfer::Connector
* Fix Spotbugs issues with AWS::Transfer::Profile
* Fix Spotbugs issues with AWS::Transfer::Workflow
* Fix Spotbugs issues with AWS::Transfer::(Server|User)

Also added coverage improvement tests for BaseHandlerStd classes.

This change is necessary due to the fact that Uluru is adding Spotbugs and specifically a new Spotbugs plugin designed to catch problems in handler implementations.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
