### PR TITLE
Make State a read-only property for Server

### DIFF
--- a/aws-transfer-server/aws-transfer-server.json
+++ b/aws-transfer-server/aws-transfer-server.json
@@ -171,6 +171,17 @@
         "PUBLIC_KEY_AND_PASSWORD"
       ]
     },
+    "State": {
+      "type": "string",
+      "enum": [
+        "OFFLINE",
+        "ONLINE",
+        "STARTING",
+        "STOPPING",
+        "START_FAILED",
+        "STOP_FAILED"
+      ]
+    },
     "Tag": {
       "type": "object",
       "properties": {
@@ -327,6 +338,9 @@
       "minLength": 19,
       "pattern": "^s-([0-9a-f]{17})$"
     },
+    "State": {
+      "$ref": "#/definitions/State"
+    },
     "StructuredLogDestinations": {
       "type": "array",
       "insertionOrder": false,
@@ -355,7 +369,8 @@
   "readOnlyProperties": [
     "/properties/Arn",
     "/properties/As2ServiceManagedEgressIpAddresses",
-    "/properties/ServerId"
+    "/properties/ServerId",
+    "/properties/State"
   ],
   "writeOnlyProperties": [
     "/properties/IdentityProviderType"

--- a/aws-transfer-server/docs/README.md
+++ b/aws-transfer-server/docs/README.md
@@ -236,3 +236,7 @@ The list of egress IP addresses of this server. These IP addresses are only rele
 
 Returns the <code>ServerId</code> value.
 
+#### State
+
+Returns the <code>State</code> value.
+

--- a/aws-transfer-server/src/main/java/software/amazon/transfer/server/BaseHandlerStd.java
+++ b/aws-transfer-server/src/main/java/software/amazon/transfer/server/BaseHandlerStd.java
@@ -232,7 +232,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         return THROTTLE_CALLBACK_DELAY_SECONDS;
     }
 
-    private String getErrorCode(Exception e) {
+    protected String getErrorCode(Exception e) {
         if (e instanceof AwsServiceException && ((AwsServiceException) e).awsErrorDetails() != null) {
             return ((AwsServiceException) e).awsErrorDetails().errorCode();
         }

--- a/aws-transfer-server/src/main/java/software/amazon/transfer/server/ReadHandler.java
+++ b/aws-transfer-server/src/main/java/software/amazon/transfer/server/ReadHandler.java
@@ -70,6 +70,7 @@ public class ReadHandler extends BaseHandlerStd {
                 .protocols(server.protocolsAsStrings())
                 .protocolDetails(ProtocolDetailsTranslator.fromSdk(server.protocolDetails()))
                 .securityPolicyName(server.securityPolicyName())
+                .state(server.stateAsString())
                 .tags(translateFromSdkTags(server.tags()))
                 .workflowDetails(WorkflowDetailsTranslator.fromSdk(server.workflowDetails()))
                 .structuredLogDestinations(server.structuredLogDestinations())

--- a/aws-transfer-server/src/test/java/software/amazon/transfer/server/AbstractTestBase.java
+++ b/aws-transfer-server/src/test/java/software/amazon/transfer/server/AbstractTestBase.java
@@ -151,6 +151,7 @@ public class AbstractTestBase {
 
     protected static DescribeServerResponse describeServerFromModel(
             String serverId, String state, ResourceModel model) {
+        model.setState(state);
         return DescribeServerResponse.builder()
                 .server(DescribedServer.builder()
                         .arn(getTestServerArn(serverId))
@@ -193,6 +194,7 @@ public class AbstractTestBase {
                 .identityProviderType(DEFAULT_IDENTITY_PROVIDER_TYPE)
                 .securityPolicyName(DEFAULT_SECURITY_POLICY)
                 .protocols(DEFAULT_PROTOCOLS)
+                .state(software.amazon.awssdk.services.transfer.model.State.ONLINE.name())
                 .structuredLogDestinations(Collections.emptyList())
                 .tags(Collections.emptyList())
                 .build();
@@ -240,6 +242,7 @@ public class AbstractTestBase {
                 .securityPolicyName(DEFAULT_SECURITY_POLICY)
                 .protocols(DEFAULT_PROTOCOLS)
                 .tags(MODEL_TAGS)
+                .state(software.amazon.awssdk.services.transfer.model.State.ONLINE.name())
                 .structuredLogDestinations(Collections.singletonList("FooLog"))
                 .loggingRole("loggingRole")
                 .preAuthenticationLoginBanner("pre")


### PR DESCRIPTION
Cloud Control needs this to be visible as a read-only property.

Also, fixed contract tests issues with tagging. The tagging test is failing in the pipeline without the changes added here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
